### PR TITLE
fix kexec_ui after #74

### DIFF
--- a/bbl_screen-patch/kexec_ui/printerui/qml/Screen.qml
+++ b/bbl_screen-patch/kexec_ui/printerui/qml/Screen.qml
@@ -24,10 +24,8 @@ import X1PlusNative 1.0
 
 import "qrc:/uibase/qml/widgets"
 
-import "printer"
-import "settings"
-import "factory"
 import "."
+import "settings"
 
 Rectangle {
     id: screen

--- a/bbl_screen-patch/kexec_ui/printerui/qml/settings/CarbonFunction.qml
+++ b/bbl_screen-patch/kexec_ui/printerui/qml/settings/CarbonFunction.qml
@@ -1,0 +1,18 @@
+pragma Singleton
+import QtQuick 2.12
+import UIBase 1.0
+import Printer 1.0
+
+import "qrc:/uibase/qml/widgets"
+import ".."
+
+Item {
+
+    function cleanCarbonRods(pageStack, dialogStack)
+    {
+    }
+
+    function silentCalibrate(pageStack, dialogStack)
+    {
+    }
+}

--- a/bbl_screen-patch/kexec_ui/root.qrc
+++ b/bbl_screen-patch/kexec_ui/root.qrc
@@ -15,6 +15,7 @@
 <file>printerui/qml/EmbededInputPanel.qml</file>
 <file>printerui/qml/EmergencyConsole.qml</file>
 <file>printerui/qml/SimplePager.qml</file>
+<file>printerui/qml/settings/CarbonFunction.qml</file>
 <file>printerui/image/cfw.png</file>
 <file>printerui/image/exclamation.svg</file>
 <file>printerui/image/roundHook.svg</file>


### PR DESCRIPTION
kexec_ui removed a little too much not to have the fallback of a printer_ui that we're accidentally loading (oops), and so #74 results in kexec_ui hanging instead of starting (!!).  (This can be solved by using the pwr+stop emergency override.) We add the appropriate bits back to allow kexec_ui to run.