### PR TITLE
add S99perf_log

### DIFF
--- a/images/cfw/etc/init.d/.x1plus_config
+++ b/images/cfw/etc/init.d/.x1plus_config
@@ -1,1 +1,0 @@
-PERF_LOG=off

--- a/images/cfw/etc/init.d/.x1plus_config
+++ b/images/cfw/etc/init.d/.x1plus_config
@@ -1,0 +1,1 @@
+PERF_LOG=off

--- a/images/cfw/etc/init.d/S99perf_log
+++ b/images/cfw/etc/init.d/S99perf_log
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-. /etc/init.d/.x1plus_config
+DEVICE_SN=$(cat /proc/cmdline | xargs -n1 | grep "bbl_serial=" | sed "s|bbl_serial=||")
 
 start() {
-	if [ PERF_LOG = on ] ; then
+	if [ -f /mnt/sdcard/x1plus/printers/$DEVICE_SN/perf_log ] ; then
 		printf "Starting perf_log"
 		start-stop-daemon -S -m -b -p /var/run/perf_log.pid --exec /opt/perf_log.sh
 	else

--- a/images/cfw/etc/init.d/S99perf_log
+++ b/images/cfw/etc/init.d/S99perf_log
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+. /etc/init.d/.x1plus_config
+
+start() {
+	if [ PERF_LOG = on ] ; then
+		printf "Starting perf_log"
+		start-stop-daemon -S -m -b -p /var/run/perf_log.pid --exec /opt/perf_log.sh
+	else
+		printf "perf_log disabled. Skipping start."
+	fi
+}
+stop() {
+	printf "Stopping perf_log"
+	start-stop-daemon -K -q -p /var/run/perf_log.pid
+        rm -f /var/run/perf_log.pid
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+restart() {
+	stop
+        sleep 5
+	start
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  restart|reload)
+	restart
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?

--- a/images/cfw/opt/perf_log.sh
+++ b/images/cfw/opt/perf_log.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-LOGFILE=/mnt/sdcard/perf_log.txt
+DEVICE_SN=$(cat /proc/cmdline | xargs -n1 | grep "bbl_serial=" | sed "s|bbl_serial=||")
+
+LOGFILE=/mnt/sdcard/x1plus/printers/$DEVICE_SN/logs/perf_log.txt
 
 date > $LOGFILE
 while true ; do

--- a/images/cfw/opt/perf_log.sh
+++ b/images/cfw/opt/perf_log.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+LOGFILE=/mnt/sdcard/perf_log.txt
+
+date > $LOGFILE
+while true ; do
+	free >> $LOGFILE
+	ps -auwxf >> $LOGFILE
+	sleep 30
+done


### PR DESCRIPTION
debugging tool for end users to try to catch issue #112 

they change /etc/init.d/.x1plus_config and change PERF_LOG=on and reboot (or /etc/init.d/S99perf_log start) and then periodic free and ps are written to /mnt/sdcard/perf_log.txt