### PR TITLE
fix the need to LD_PRELOAD libffi into python

### DIFF
--- a/images/cfw/etc/init.d/S82gpiokeys
+++ b/images/cfw/etc/init.d/S82gpiokeys
@@ -2,7 +2,6 @@
 
 start() {
 	printf "Grabbing gpiokeys"
-	export LD_PRELOAD=/opt/python/lib/libffi.so
 	start-stop-daemon -S -m -b -p /var/run/gpiokeys.pid --exec /opt/python/bin/python3 -- /opt/gpiokeys.py
 }
 stop() {

--- a/images/cfw/etc/init.d/S93syslog_shim
+++ b/images/cfw/etc/init.d/S93syslog_shim
@@ -2,7 +2,6 @@
 
 start() {
 	printf "Starting syslog shim service: "
-    export LD_PRELOAD=/opt/python/lib/libffi.so
 	start-stop-daemon -S -m -b -p /var/run/syslog_shim_service.pid --exec /opt/python/bin/python3 -- /opt/syslog_shim.py
 }
 stop() {

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -7,4 +7,4 @@ cd $(dirname $0)
 io -4 -w 0xfe010050 0x11001100
 
 # Launch installer
-PYTHONUNBUFFERED=1 LD_LIBRARY_PATH=`pwd`/lib LD_PRELOAD=`pwd`/lib/libffi.so exec bin/python3 install.py 2>&1 | tee /mnt/sdcard/x1plus_installer_log.txt | tee /dev/ttyFIQ0
+PYTHONUNBUFFERED=1 exec bin/python3 install.py 2>&1 | tee /mnt/sdcard/x1plus_installer_log.txt | tee /dev/ttyFIQ0


### PR DESCRIPTION
patchelf python and its libraries to load from /opt/python/lib, and also patchelf ctypes to load libffi, and also strip python libraries to save quite a bit of space (fixes #111)