### PR TITLE
Jwise/fix printingpng

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
@@ -13,8 +13,8 @@
      property var carouselImages: WebContents.carouselImages2
      property bool printPrepare: task.state < PrintTask.RUNNING && task.state > PrintTask.IDLE
 +    property var serialNo: DeviceManager.build.seriaNO
-+    property var f1: "file://" + DeviceManager.getSetting("cfw_home_image", `/mnt/sdcard/x1plus/${serialNo}/images/home.png`)
-+    property var img1: imgExists(f1) ? f1: "qrc:/printerui/image/exhibition.png"
++    property var f1: "file://" + DeviceManager.getSetting("cfw_print_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
++    property var img1: imgExists(f1) ? f1: "qrc:/printerui/image/exhibition1.png"
      property var stateIcons: {
          var icons = []
          if (RecordManager.isTimelapseOn) {


### PR DESCRIPTION
This fixes the image display issue and cleans up variable names. I have tested and confirmed it's fixed on my device, and anyone who wants to test it can do so by editing printer.json like so:

`"cfw_print_image": "/mnt/sdcard/test1.png",`
`"cfw_home_image": "/mnt/sdcard/test2.png",`

replace the filepaths with your own, of course. 

I think we should remove the hardcoded paths, because it only seems to be a source of confusion for users trying to set custom background images. 