### PR TITLE
Automatically upload base.ts to CrowdIn on master push.

### DIFF
--- a/.github/workflows/x1p-build.yml
+++ b/.github/workflows/x1p-build.yml
@@ -38,6 +38,16 @@ jobs:
         jwise0/cfwbuild:v3 /bin/bash -c "git config --global --add safe.directory /work; make"
       env:
         UPDATE_KEY_MATERIAL: ${{ secrets.UPDATE_KEY_MATERIAL }}
+    - name: Upload sources to CrowdIn
+      if: startsWith(github.ref, 'refs/heads/main')
+      uses: crowdin/github-action@v1
+      with:
+        upload_sources: true
+        download_sources: false
+        download_translations: false
+        source: bbl_screen-patch/base.ts
+        project_id: 659058
+        token: ${{ secrets.CROWDIN_UPLOAD_SOURCE_TOKEN }}
     - name: remote upload x1p artifact
       if: startsWith(github.ref, 'refs/tags/x1plus/') || startsWith(github.ref, 'refs/heads/main')
       run: |


### PR DESCRIPTION
Uses the 'no-crowdin.yml' configuration suggested [here](https://github.com/crowdin/github-action/blob/master/EXAMPLES.md#upload-sources-only), but the nice thing about CI is there's no way to test CI except in prod, so I guess we're going to just have to send it.

I may have to rambo changes into main to fix this if it's fucked, so, you know, heads up on that front.