### PR TITLE
Print and home image display corrected (issue 82 fix)

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/qml/main/Home2Page.qml
 +++ printer_ui/printerui/qml/main/Home2Page.qml
-@@ -2,6 +2,7 @@
+@@ -2,10 +2,12 @@
  import QtQuick.Controls 2.12
  import UIBase 1.0
  import Printer 1.0
@@ -8,32 +8,22 @@
  
  import ".."
  import "../printer"
-@@ -16,6 +17,9 @@
+ import "../models"
++import "../X1Plus.js" as X1Plus
+ import "qrc:/uibase/qml/widgets"
+ 
+ Item {
+@@ -16,6 +18,9 @@
      property bool printing: task.stage >= PrintTask.WORKING
      property var carouselImages: WebContents.carouselImages2
      property bool printPrepare: task.state < PrintTask.RUNNING && task.state > PrintTask.IDLE
 +    property var serialNo: DeviceManager.build.seriaNO
-+    property var f1: "file://" + DeviceManager.getSetting("cfw_print_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
-+    property var img1: imgExists(f1) ? f1: "qrc:/printerui/image/exhibition1.png"
++    property var print_png: DeviceManager.getSetting("cfw_print_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
++    property var img_print: X1Plus.fileExists(print_png) ? "file://" + print_png: "qrc:/printerui/image/exhibition1.png"
      property var stateIcons: {
          var icons = []
          if (RecordManager.isTimelapseOn) {
-@@ -29,6 +33,14 @@
- //        }
-         return icons
-     }
-+    function imgExists(img){
-+        var strPath = img.replace("file://","");
-+        if (X1PlusNative.popen(`test -f ${strPath} && echo 1 || echo 0`) == 0){
-+            return false;
-+        } else {
-+            return true;
-+        }
-+    }
- 
-     EventTrack.pageName: "Home2"
- 
-@@ -296,7 +308,8 @@
+@@ -296,7 +301,8 @@
          topMargin: statusPanel.topMargin
          bottomMargin: statusPanel.bottomMargin
          color: hmsItem.visible ? Colors.gray_700: Colors.gray_600
@@ -43,12 +33,12 @@
          ZCarouselView {
              anchors.fill: parent
              anchors.margins: 10
-@@ -304,7 +317,7 @@
+@@ -304,7 +310,7 @@
              orientation: Qt.Vertical
              visible: !hmsItem.visible && !printStep.visible
              model: carouselImages.length === 0
 -                   ? [ "qrc:/printerui/image/exhibition1.png" ]
-+                   ? [ img1 ]
++                   ? [ img_print ]
                     : carouselImages.map(function(i) { return i.imageUrl })
          }
  

--- a/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/qml/main/HomePage.qml
 +++ printer_ui/printerui/qml/main/HomePage.qml
-@@ -2,6 +2,7 @@
+@@ -2,17 +2,25 @@
  import QtQuick.Controls 2.12
  import UIBase 1.0
  import Printer 1.0
@@ -8,37 +8,33 @@
  
  import ".."
  import "../printer"
-@@ -11,8 +12,22 @@
++import "../X1Plus.js" as X1Plus
+ import "qrc:/uibase/qml/widgets"
+ 
+ Item {
  
      property var carouselImages: hmsPanel.visible
                                   ? WebContents.carouselImages2 : WebContents.carouselImages1
+-
 +    property var serialNo: DeviceManager.build.seriaNO
-+    property var f2: "file://" + DeviceManager.getSetting("cfw_home_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/home.png`)
-+    property var f1: "file://"+ DeviceManager.getSetting("cfw_print_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
-+    property var img1: imgExists(f1) ? f1: "qrc:/printerui/image/exhibition1.png"
-+    property var img2: imgExists(f2) ? f2: "qrc:/printerui/image/exhibition.png"
- 
++    property var home_png: DeviceManager.getSetting("cfw_home_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/home.png`)
++    property var print_png: DeviceManager.getSetting("cfw_print_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
++    property var img_print: X1Plus.fileExists(print_png) ? "file://"+print_png: "qrc:/printerui/image/exhibition1.png"
++    property var img_home: X1Plus.fileExists(home_png) ? "file://"+home_png: "qrc:/printerui/image/exhibition.png" 
      EventTrack.pageName: "Home"
 +    
-+    function imgExists(img){
-+        var strPath = img.replace("file://","");
-+        if (X1PlusNative.popen(`test -f ${strPath} && echo 1 || echo 0`) == 0){
-+            return false;
-+        } else {
-+            return true;
-+        }
-+    }
++    
  
      MarginPanel {
          id: showPanel
-@@ -30,8 +45,8 @@
+@@ -30,8 +38,8 @@
              interval: 10000
              orientation: hmsPanel.visible ? Qt.Vertical : Qt.Horizontal
              model: carouselImages.length === 0
 -                   ? [ hmsPanel.visible ? "qrc:/printerui/image/exhibition1.png"
 -                                        : "qrc:/printerui/image/exhibition.png" ]
-+                   ? [ hmsPanel.visible ? img1
-+                                        : img2 ]
++                   ? [ hmsPanel.visible ? img_print
++                                        : img_home ]
                     : carouselImages.map(function(i) { return i.imageUrl })
          }
      }


### PR DESCRIPTION
When this PR was approved [link](https://github.com/X1Plus/X1Plus/commit/fcce8c9b03c06bc8903724bba9bd25f2459a6da8) my changes on the branch didn't get merged, and these revisions are necessary to fix the error. I have live tested this 

Original commits on the branch:
https://github.com/X1Plus/X1Plus/commit/9844851e5cc151fefc5722ab44186f0a7860f98b

For anyone wanting to test the bug fix, please see the "undocumented feature" I added to the wiki. Copy and paste those keys into your printer.json and restart the screen. [Home and Print images](https://github.com/X1Plus/X1Plus/wiki/Undocumented-Linux-Features#viewing-lidar-camera-images)