### PR TITLE
Avoid leaving bad NumberPads around on the DialogStack if the lock screen is interrupted

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
@@ -89,15 +89,12 @@ Rectangle {
                     locked = false;
                 }
             }
-            ersatzDialogStack.pop();
         }
     }
 
     function popNumberPad() {
         isEnteringPasscode = true;
         numberPad.target = top;
-        /* this is admittedly extremely silly, since the dialogStack is beneath us */
-        ersatzDialogStack.push(dialogStack.currentItem);
     }
 
     ColumnLayout {
@@ -117,7 +114,7 @@ Rectangle {
             onXChanged: {
                 /* this is *astonishingly* chaotic */
                 if (isEnteringPasscode) {
-                    ersatzDialogStack.currentItem.focusPosition = ersatzDialogStack.currentItem.mapFromItem(lockText, 0, 0);
+                    dialogStack.currentItem.focusPosition = dialogStack.currentItem.mapFromItem(lockText, 0, 0);
                 }
             }
         }
@@ -200,8 +197,10 @@ Rectangle {
         }
     }
     
+    /* Shadow the global dialogStack here -- that dialogStack is hidden, but
+     * the NumberPad uses it to push and pop things.  Ours isn't hidden. */
     StackView {
-        id: ersatzDialogStack
+        id: dialogStack
         anchors.fill: parent
         initialItem: Item { objectName: "initialItem" }
         pushEnter: null

--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
@@ -63,6 +63,8 @@ Rectangle {
         if (DeviceManager.getSetting("cfw_locktype", 0) != 0) {
             locked = true;
             readText();
+            isEnteringPasscode = false;
+            numberPad.target = null;
         }
     }
     


### PR DESCRIPTION
Previously, we used this sort of hokey `ersatzDialogStack` and tried to mirror the real `dialogStack`'s state onto it (because the real `dialogStack` was hidden beneath the lock screen).  This was fine except if another dialog came in the middle, which would result in the `NumberPad` becoming very upset, and maybe-or-maybe-not popping the right thing off the stack, and leaving the system in an inconsistent state.

I don't know why I didn't do this to begin with, but this time I just shadow the `dialogStack` so that the `NumberPad` refers to the one that is currently active (i.e., the one that is above the lock screen).  That way the two are not weirdly intertwined.

While I'm in here, I make sure that the `NumberPad` is closed when the screen relocks, which seemed like a silly oversight as well.

Fixes #126.