### PR TITLE
syslog_shim encoding fix

### DIFF
--- a/images/cfw/opt/logger/tail.py
+++ b/images/cfw/opt/logger/tail.py
@@ -20,7 +20,7 @@ class TailLog:
                 self.buf += self.fd.read() + "\n"
                 self.fd.close()
             print(f"TailLog: reopened {self.filepath} and finished up {len(self.buf)} bytes", file = sys.stderr)
-            self.fd = open(self.filepath, "r")
+            self.fd = open(self.filepath, "r", encoding="utf-8", errors="replace")
             self.ino = os.fstat(self.fd.fileno()).st_ino
 
         # Grab some data from the buffer; if it's the first go-around, throw


### PR DESCRIPTION
Prevent syslog_shim.py from being killed by UnicodeDecodeErrors

If any non UTF-8 characters end up in syslog, syslog_shim.py throws a UnicodeDecodeError and does not run. Opening the file with errors="replace" handles this error.