### PR TITLE
Build from GHCR rather than Docker Hub

### DIFF
--- a/.github/workflows/x1p-build.yml
+++ b/.github/workflows/x1p-build.yml
@@ -35,7 +35,7 @@ jobs:
         -v ${{ github.workspace }}:/work \
         -u `id -u` \
         --env-file <(env | grep "GITHUB\|UPDATE_KEY_MATERIAL") \
-        jwise0/cfwbuild:v3 /bin/bash -c "git config --global --add safe.directory /work; make"
+        ghcr.io/x1plus/x1plus-build:v3.1 /bin/bash -c "git config --global --add safe.directory /work; make"
       env:
         UPDATE_KEY_MATERIAL: ${{ secrets.UPDATE_KEY_MATERIAL }}
     - name: Upload sources to CrowdIn


### PR DESCRIPTION
Now that we have a public repository, let's use a GHCR image to go more faster.  This still doesn't autobuild the Docker image into GHCR (that step happens manually on my laptop) but it's better than it was before.