### PR TITLE
Bind the new BDbus library to QML

### DIFF
--- a/bbl_screen-patch/Makefile
+++ b/bbl_screen-patch/Makefile
@@ -64,8 +64,11 @@ base.ts: printer_ui.so kexec_ui.so
 %.so: %.c
 	$(TARGET_CC) -o $@ $< $(CFLAGS) $(LDFLAGS)
 
-%.so: %.ui.o interpose.cpp interpose.moc.h
+kexec_ui.so: kexec_ui.ui.o interpose.cpp interpose.moc.h
 	$(TARGET_CC) -o $@ $< interpose.cpp workaround_ifaddrs.c $(CXXFLAGS) $(LDFLAGS) -I $(QT5_INCL_PATH)
+
+printer_ui.so: printer_ui.ui.o interpose.cpp interpose.moc.h
+	$(TARGET_CC) -o $@ $< interpose.cpp workaround_ifaddrs.c $(CXXFLAGS) $(LDFLAGS) -I $(QT5_INCL_PATH) -DHAS_DBUS
 
 %.moc.h: %.cpp
 	moc -I $(QT5_INCL_PATH) $< -o $@

--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -167,3 +167,4 @@ X1Plus.DBus.registerMethod("ping", (param) => {
     param["pong"] = "from QML";
     return param;
 });
+X1Plus.DBus.onSignal("x1plus.screen", "log", (param) => console.log(param.text));

--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -9,6 +9,7 @@
 .import "./x1plus/GcodeGenerator.js" as X1PlusGcodeGenerator
 .import "./x1plus/BedMeshCalibration.js" as X1PlusBedMeshCalibration
 .import "./x1plus/ShaperCalibration.js" as X1PlusShaperCalibration
+.import "./x1plus/DBus.js" as X1PlusDBus
 
 /* Back-end model logic for X1Plus's UI
  *
@@ -48,12 +49,15 @@ X1Plus.ShaperCalibration = X1PlusShaperCalibration;
 var ShaperCalibration = X1PlusShaperCalibration;
 X1Plus.GpioKeys = X1PlusGpioKeys;
 var GpioKeys  = X1PlusGpioKeys;
+X1Plus.DBus = X1PlusDBus;
+var DBus = X1PlusDBus;
 
 Stats.X1Plus = X1Plus;
 DDS.X1Plus = X1Plus;
 BedMeshCalibration.X1Plus = X1Plus;
 ShaperCalibration.X1Plus = X1Plus;
 GpioKeys.X1Plus = X1Plus;
+DBus.X1Plus = X1Plus;
 
 var _DdsListener = JSDdsListener.DdsListener;
 var _X1PlusNative = JSX1PlusNative.X1PlusNative;
@@ -158,3 +162,8 @@ function awaken(_DeviceManager, _PrintManager, _PrintTask) {
 	ShaperCalibration.awaken();
 	GpioKeys.awaken();
 }
+
+X1Plus.DBus.registerMethod("ping", (param) => {
+    param["pong"] = "from QML";
+    return param;
+});

--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -164,7 +164,13 @@ function awaken(_DeviceManager, _PrintManager, _PrintTask) {
 }
 
 X1Plus.DBus.registerMethod("ping", (param) => {
-    param["pong"] = "from QML";
-    return param;
+	param["pong"] = "from QML";
+	return param;
 });
 X1Plus.DBus.onSignal("x1plus.screen", "log", (param) => console.log(param.text));
+X1Plus.DBus.registerMethod("TryRpc", (param) => {
+	console.log("trying an RPC to x1plus hello daemon");
+	var f = X1Plus.DBus.proxyFunction("x1plus.hello", "/x1plus/hello", "x1plus.hello", "PingPong");
+	param["resp"] = f("hello");
+	return param;
+});

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
@@ -1,0 +1,49 @@
+.pragma library
+.import DBusListener 1.0 as JSDBusListener
+
+/* Glue logic to connect Bambu DBus to QML
+ *
+ * Copyright (c) 2024 Joshua Wise, and the X1Plus authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+var _DBusListener = JSDBusListener.DBusListener;
+
+var X1Plus = null;
+
+var _componentFactory = Qt.createComponent("DBusObject.qml");
+var _DBusObject = _componentFactory.createObject();
+
+var _methods = {};
+
+function _handleDbus(method, param) {
+    var fn = _methods[method];
+    if (!fn) {
+        console.log(`*** handleDbus got invalid method ${method} -- this should not be!`);
+        return;
+    }
+    return JSON.stringify(fn(JSON.parse(param)));
+}
+_DBusObject.handler = _handleDbus; // ugh
+_DBusListener.handler = _DBusObject;
+
+function registerMethod(name, fn) {
+    if (_methods[name]) {
+        console.log(`*** X1Plus.DBus.registerMethod called twice for ${name}?`);
+    } else {
+        _DBusListener.registerMethod(name);
+    }
+    _methods[name] = fn;
+}

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
@@ -65,3 +65,18 @@ function onSignal(path, name, fn) {
     }
     _signals[p].push(fn);
 }
+
+var _proxies = {};
+
+function proxyFunction(busName, objName, interface, method) {
+    if (!_proxies[busName]) {
+        _proxies[busName] = {};
+    }
+    if (!_proxies[busName][objName]) {
+        _proxies[busName][objName] = _DBusListener.createProxy(busName, objName);
+    }
+    return (j) => {
+        var s = _proxies[busName][objName].callMethod(interface, method, JSON.stringify(j));
+        return JSON.parse(s);
+    };
+}

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DBusObject.qml
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DBusObject.qml
@@ -1,0 +1,9 @@
+import QtQuick 2.12
+
+QtObject {
+    property var handler: null
+    function dbusMethodCall(method, param) {
+        return handler(method, param);
+    }
+}
+

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DBusObject.qml
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DBusObject.qml
@@ -1,9 +1,13 @@
 import QtQuick 2.12
 
 QtObject {
-    property var handler: null
+    property var methodCallHandler: null
+    property var signalHandler: null
     function dbusMethodCall(method, param) {
-        return handler(method, param);
+        return methodCallHandler(method, param);
+    }
+    function dbusSignal(path, name, param) {
+        signalHandler(path, name, param);
     }
 }
 

--- a/bbl_screen-patch/patches/root.qrc.patch
+++ b/bbl_screen-patch/patches/root.qrc.patch
@@ -112,7 +112,7 @@
  <file>printerui/qml/settings/WifiListPage.qml</file>
  <file>printerui/qml/settings/WifiSetupPage.qml</file>
  <file>printerui/qml/wizard/Calibrate1Page.qml</file>
-@@ -235,12 +283,24 @@
+@@ -235,12 +283,26 @@
  <file>printerui/qml/wizard/TermsPage.qml</file>
  <file>printerui/qml/wizard/WelcomePage.qml</file>
  <file>printerui/qml/wizard/WizardPage.qml</file>
@@ -121,6 +121,8 @@
 +<file>printerui/qml/x1plus/BedMeshCalibration.js</file>
 +<file>printerui/qml/x1plus/Binding.js</file>
 +<file>printerui/qml/x1plus/Bindable.qml</file>
++<file>printerui/qml/x1plus/DBus.js</file>
++<file>printerui/qml/x1plus/DBusObject.qml</file>
 +<file>printerui/qml/x1plus/DDS.js</file>
 +<file>printerui/qml/x1plus/GcodeGenerator.js</file>
 +<file>printerui/qml/x1plus/GpioKeys.js</file>
@@ -137,7 +139,7 @@
  <file>printerui/text/error_texts.sv.json</file>
  <file>printerui/text/error_texts.zh-cn.json</file>
  <file>printerui/text/error_texts.zh-tw.json</file>
-@@ -259,6 +319,7 @@
+@@ -259,6 +321,7 @@
  <file>printerui/text/hms_texts.fr.json</file>
  <file>printerui/text/hms_texts.ja.json</file>
  <file>printerui/text/hms_texts.nl.json</file>
@@ -145,7 +147,7 @@
  <file>printerui/text/hms_texts.sv.json</file>
  <file>printerui/text/hms_texts.zh-cn.json</file>
  <file>printerui/text/hms_texts.zh-tw.json</file>
-@@ -295,3 +356,4 @@
+@@ -295,3 +358,4 @@
  <file>printerui/text/terms.zh-cn.txt</file>
  <file>qt-project.org/imports/QtQuick/VirtualKeyboard/Styles/bbl/style.qml</file>
  </qresource></RCC>


### PR DESCRIPTION
Bambu Lab are moving to DBus now in the newest beta firmware, and all things told, this is a lot better than DDS.  In this PR, we introduce a mechanism to plumb DBus function calls and signals into QML, as well as outbound DBus function calls, so we can take action inside the UI.  Right now we implement only a `ping` command and a `log` signal, which you can try with:

```
dbus-send --session --type=signal / x1plus.screen.log string:'{"text": "hello, world"}'
dbus-send --session --print-reply --dest=bbl.service.screen /bbl/service/screen bbl.screen.x1plus.ping string:'{"text": "hello from DBus"}'
```

These commands are in emulation; on the real system, you will want to use `--system` instead of `--session`.  This lays the groundwork for being able to call RPCs into QML, and report events into QML.

Additionally, you can run an "X1Plus hello world" service elsewhere on the system which responds to RPCs from inside QML.  Try running the following elsewhere on your host:

```python
from dasbus.connection import SessionMessageBus
from dasbus.server.interface import dbus_interface
from dasbus.typing import Str
import json

@dbus_interface("x1plus.hello")
class X1PlusHello(object):

    def PingPong(self, arg: Str) -> Str:
        print(f"pingd: {arg}")
        arg = json.loads(arg)
        return json.dumps(f"Pong {arg}")

print(X1PlusHello.__dbus_xml__)

bus = SessionMessageBus()
bus.publish_object("/x1plus/hello", X1PlusHello())
bus.register_service("x1plus.hello")

from dasbus.loop import EventLoop
loop = EventLoop()
loop.run()
```

Then, you can trigger bbl_screen to call into this:
```
$ dbus-send --session --print-reply --dest=bbl.service.screen /bbl/service/screen bbl.screen.x1plus.TryRpc string:'{"text": "hello from DBus"}'
method return time=1714115957.022830 sender=:1.2523 -> destination=:1.2525 serial=11 reply_serial=2
   string "{"text":"hello from DBus","resp":"Pong hello"}"
```

This is two DBus calls for the price of one: bbl_screen listens to DBus, and then it spits out a DBus call, and then returns what it heard back from that DBus call.