### PR TITLE
ScreenLock: take an extremely belt-and-suspenders approach to making sure that we do not pop a box multiple times (fixes #194)

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
@@ -56,6 +56,7 @@ Rectangle {
     }
     
     TapHandler {
+        gesturePolicy: TapHandler.ReleaseWithinBounds | TapHandler.WithinBounds
         onTapped: { }
     }
     

--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
@@ -53,6 +53,7 @@ Rectangle {
             didSleep();
             locked = true;
         }
+        dialogStack.push(dummyStackItem);
     }
     
     TapHandler {
@@ -65,6 +66,7 @@ Rectangle {
             readText();
             isEnteringPasscode = false;
             numberPad.target = null;
+            dialogStack.clear(); // in case anything got left over somehow...
         }
     }
     
@@ -86,6 +88,7 @@ Rectangle {
         focusItem: lockText
         onFinished: {
             isEnteringPasscode = false;
+            target = null;
             if (!cancel) {
                 if (number == passcode) {
                     locked = false;
@@ -95,8 +98,10 @@ Rectangle {
     }
 
     function popNumberPad() {
-        isEnteringPasscode = true;
-        numberPad.target = top;
+        if (!isEnteringPasscode) {
+            isEnteringPasscode = true;
+            numberPad.target = top;
+        }
     }
 
     ColumnLayout {
@@ -169,7 +174,7 @@ Rectangle {
                 border.width: 3
                 
                 DragHandler {
-                    xAxis.enabled: true
+                    xAxis.enabled: !isEnteringPasscode
                     xAxis.minimum: 0
                     xAxis.maximum: parent.parent.width - parent.width
                     yAxis.enabled: false
@@ -209,5 +214,14 @@ Rectangle {
         pushExit: null
         popEnter: null
         popExit: null
+    }
+    
+    // "StackView.pop()" apparently is a no-op not just when depth is 0, BUT
+    // WHEN IT IS 1 ALSO.  So you cannot pop() down to the initialItem, you
+    // can only clear() down to it.  Fucking QML!
+    Component {
+        id: dummyStackItem
+        Item {
+        }
     }
 }

--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
@@ -53,7 +53,6 @@ Rectangle {
             didSleep();
             locked = true;
         }
-        dialogStack.push(dummyStackItem);
     }
     
     TapHandler {
@@ -67,6 +66,7 @@ Rectangle {
             isEnteringPasscode = false;
             numberPad.target = null;
             dialogStack.clear(); // in case anything got left over somehow...
+            dialogStack.push(dummyStackItem);
         }
     }
     


### PR DESCRIPTION
There were a handful of ways that the screen lock could go wrong.  We shore up many of them:

* The StackView apparently did not work at all when we tried to `pop` from it.  We give it a dummy item so that it is permitted to `pop`.
* If you somehow manage to tap behind the number pad without dismissing it, it would be good to make sure that the thumb is not draggable.
* If you somehow manage to tap the number pad and drag the thumb, it would be good to avoid popping the number pad twice.

Hopefully this fixes #194 once and for all.