### PR TITLE
Allow creating cron jobs

### DIFF
--- a/images/cfw/etc/init.d/S99crontab
+++ b/images/cfw/etc/init.d/S99crontab
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DEVICE_SN=$(cat /proc/cmdline | xargs -n1 | grep "bbl_serial=" | sed "s|bbl_serial=||")
+DEVICE_SN=$(bbl_3dpsn 2> /dev/null)
 
 CRONTAB_FILE="/mnt/sdcard/x1plus/printers/$(DEVICE_SN)/crontab"
 

--- a/images/cfw/etc/init.d/S99crontab
+++ b/images/cfw/etc/init.d/S99crontab
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+DEVICE_SN=$(cat /proc/cmdline | xargs -n1 | grep "bbl_serial=" | sed "s|bbl_serial=||")
+
+CRONTABS_DIR="/mnt/sdcard/x1plus/printers/$(DEVICE_SN)/crontab"
+
+start() {
+    if [ -f "$CRONTABS_DIR" ]; then
+        mkdir -p /var/spool/cron/crontabs
+        ln -sf "$CRONTABS_DIR" /var/spool/cron/crontabs/root
+        echo "Starting crond..."
+        start-stop-daemon -S -m -b -p /var/run/crond.pid --exec crond
+        [ $? = 0 ] && echo "OK" || echo "FAIL"
+    else
+        echo "No crontab found, not starting crond."
+    fi
+}
+
+stop() {
+    printf "Stopping crond service: "
+    start-stop-daemon -K -q -p /var/run/crond.pid
+    [ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+
+restart() {
+    stop
+    sleep 5
+    start
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart|reload)
+    restart
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+    exit 1
+esac
+
+exit $?

--- a/images/cfw/etc/init.d/S99crontab
+++ b/images/cfw/etc/init.d/S99crontab
@@ -2,12 +2,12 @@
 
 DEVICE_SN=$(cat /proc/cmdline | xargs -n1 | grep "bbl_serial=" | sed "s|bbl_serial=||")
 
-CRONTABS_DIR="/mnt/sdcard/x1plus/printers/$(DEVICE_SN)/crontab"
+CRONTAB_FILE="/mnt/sdcard/x1plus/printers/$(DEVICE_SN)/crontab"
 
 start() {
-    if [ -f "$CRONTABS_DIR" ]; then
+    if [ -f "$CRONTAB_FILE" ]; then
         mkdir -p /var/spool/cron/crontabs
-        ln -sf "$CRONTABS_DIR" /var/spool/cron/crontabs/root
+        ln -sf "$CRONTAB_FILE" /var/spool/cron/crontabs/root
         echo "Starting crond..."
         start-stop-daemon -S -m -b -p /var/run/crond.pid --exec crond
         [ $? = 0 ] && echo "OK" || echo "FAIL"


### PR DESCRIPTION
Allow users to define cron jobs by placing a crontab at `x1plus/printers/<serialnumber>/` on their SD card. Only starts `crond` if the file is found.

Wasn't sure which prefix to add to the `init.d` entry, so I went with `S99`, let me know if this should be something else. Also, this should probably be added to the wiki, but I couldn't find how to add that to the PR.