### PR TITLE
ci: logging and file improvements

### DIFF
--- a/bbl_screen-patch/.gitignore
+++ b/bbl_screen-patch/.gitignore
@@ -6,3 +6,4 @@
 *_moc.cpp
 *_moc.h
 *.ui.cpp
+base.ts

--- a/firmwares/Makefile
+++ b/firmwares/Makefile
@@ -16,7 +16,7 @@ clean-all: clean
 	@rm -fv *.img.zip.sig
 
 define fetchimage =
-	wget -N -c "https://public-cdn.bambulab.com/upgrade/device/BL-P001/$(1)/product/$(2)$(3)"
+	wget -q -N -c "https://public-cdn.bambulab.com/upgrade/device/BL-P001/$(1)/product/$(2)$(3)"
 	../scripts/repack_update.py $(3) $(4)
 endef
 


### PR DESCRIPTION
* Silence our wget of the BBL firmware, it's over 50% of our build logs
* gitignore our ts file, since it's pulled on build and not committed to the repo.