### PR TITLE
fix: add buildtimestamp to ota file

### DIFF
--- a/scripts/mkinfojson.py
+++ b/scripts/mkinfojson.py
@@ -9,6 +9,8 @@ ROOTPATH = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__
 
 BASE = json.load(open(f"{ROOTPATH}/installer/base.json", "r"))
 
+timestamp = datetime.datetime.now().timestamp()
+
 try:
     rv = subprocess.run(["git", "describe", "--tags", "--match", "x1plus/*", "--abbrev=7", "--dirty"], capture_output=True, check=True, cwd=ROOTPATH)
     describe = rv.stdout.decode().strip().split('-')
@@ -39,6 +41,7 @@ else:
         {
             "cfwVersion": cfwVersion,
             "date": cfwdate,
+            "buildTimestamp": timestamp,
             "notes": tagnotes,
             "url": f"https://github.com/X1Plus/X1Plus/releases/download/x1plus%2F{cfwVersion}/{cfwVersion}.x1p"
         },
@@ -51,6 +54,7 @@ json.dump(
     {
         "cfwVersion": cfwVersion,
         "date": cfwdate,
+        "buildTimestamp": timestamp,
         "notes": tagnotes,
         "base": BASE
     },


### PR DESCRIPTION
TL;DR it's hard to compare builds with our current naming scheme, so let's add a build timestamp that can be used for this compare.