### PR TITLE
SD logging for syslog_shim logger

### DIFF
--- a/images/cfw/opt/syslog_shim.py
+++ b/images/cfw/opt/syslog_shim.py
@@ -7,7 +7,17 @@ from collections import namedtuple
 from logger.tail import TailLog
 import dds
 
-syslog_log = CustomLogger("Syslog parser", "/tmp/x1plus_data.log", 500000, 1)
+# Log setup - Check if SD logging is enabled
+# Start up our own logger (to sd card if SD logging, /tmp/ if not)
+log_path = (
+    "/mnt/sdcard/log/"
+    if os.path.exists("/tmp/.syslog_to_sd") and os.path.exists("/mnt/sdcard/log/")
+    else "/tmp/"
+)
+shim_log_path = os.path.join(log_path,"x1plus_data.log")
+syslog_log = CustomLogger("Syslog shim data", shim_log_path, 500000, 1)
+log_path = os.path.join(log_path,"syslog.log")
+
 
 # Define a basic mechanism for "do something when you see some particular
 # type of line in the syslog".
@@ -117,16 +127,18 @@ syslog_data = [
             },
         },
     ),
+    # M1005 skew factor
+    RegexParser(
+        r".*M1005:current\s*XY_comp_ang\s*=\s*(-?\d+\.?\d*)",
+        lambda match: {
+            "command": "M1005",
+            "XY_comp_ang":  float(match.group(1)),
+        },
+    ),
 ]
 
 
 def main():
-    log_path = (
-        "/mnt/sdcard/log/syslog.log"
-        if os.path.exists("/tmp/.syslog_to_sd") and os.path.exists("/mnt/sdcard/log/syslog.log")
-        else "/tmp/syslog.log"
-    )
-
     tail_syslog = TailLog(log_path)
     for line in tail_syslog.lines():
         for handler in syslog_data:

--- a/images/cfw/opt/syslog_shim.py
+++ b/images/cfw/opt/syslog_shim.py
@@ -129,10 +129,13 @@ syslog_data = [
     ),
     # M1005 skew factor
     RegexParser(
-        r".*M1005:current\s*XY_comp_ang\s*=\s*(-?\d+\.?\d*)",
+        r".*M1005:(new|current)\s*XY_comp_ang\s*=\s*(-?\d+\.?\d*)",
         lambda match: {
             "command": "M1005",
-            "XY_comp_ang":  float(match.group(1)),
+            "param": {
+                "skew":  match.group(1),
+                "XY_comp_ang":  float(match.group(2)),
+            },
         },
     ),
 ]


### PR DESCRIPTION
syslog_shim.py checks to see if SD logging is enabled, but it still saves its own log to /tmp/ no matter what.

I've fixed that here. 

Also added regex to syslog_shim.py so it will capture skew factor data:

```
[MCU][BMC]M1005:current XY_comp_ang = 0.00110
[MCU][BMC]M1005:new XY_comp_ang = -0.00097
```

Note: These changes and syslog_shim.py as a whole will become mostly irrelevant as soon as we set up syslog-ng