### PR TITLE
Use the correct MD5 for the 00.00.32.17 squashfs.

### DIFF
--- a/installer/base.json
+++ b/installer/base.json
@@ -5,6 +5,6 @@
     "updateName": "update-v00.00.32.17-20240409222723_product.img.zip.sig",
     "updateMd5": "d207b19601befe17e49eee3d2d804593",
     "squashfsName": "00.00.32.17.squashfs",
-    "squashfsMd5": "XXX",
+    "squashfsMd5": "29d068d4b0dacab7cbac5b53e20febf7",
     "mtime": 1712648206
 }


### PR DESCRIPTION
Fixes an issue in which the installer would always regenerate the squashfs, even if it had a good one there.

Oops.  My b.