### PR TITLE
start using the new standard for settings key, and migrate image locations to x1plus settings

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
@@ -20,7 +20,7 @@
      property var defaultImage: DeviceManager.getSystemSetting("device/images_path")
      property bool printPrepare: task.state < PrintTask.RUNNING && task.state > PrintTask.IDLE
 +    property var serialNo: DeviceManager.build.seriaNO
-+    property var print_png: DeviceManager.getSetting("cfw_print_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
++    property var print_png: X1Plus.Settings.get("homescreen.image.printing", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
 +    property var img_print: X1Plus.fileExists(print_png) ? "file://" + print_png: "qrc:/printerui/image/exhibition1.png"
      property var stateIcons: {
          var icons = []

--- a/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
@@ -17,8 +17,8 @@
                                   ? WebContents.carouselImages2 : WebContents.carouselImages1
 -    property var defaultImage: DeviceManager.getSystemSetting("device/images_path")
 +    property var serialNo: DeviceManager.build.seriaNO
-+    property var home_png: DeviceManager.getSetting("cfw_home_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/home.png`)
-+    property var print_png: DeviceManager.getSetting("cfw_print_image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
++    property var home_png: X1Plus.Settings.get("homescreen.image", `/mnt/sdcard/x1plus/printers/${serialNo}/images/home.png`)
++    property var print_png: X1Plus.Settings.get("homescreen.image.printing", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
 +    property var img_print: X1Plus.fileExists(print_png) ? "file://"+print_png: "qrc:/printerui/image/exhibition1.png"
 +    property var img_home: X1Plus.fileExists(home_png) ? "file://"+home_png: "qrc:/printerui/image/exhibition.png" 
      EventTrack.pageName: "Home"

--- a/bbl_screen-patch/patches/printerui/qml/settings/DevicePage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/settings/DevicePage.qml.patch
@@ -1,11 +1,12 @@
 --- printer_ui-orig/printerui/qml/settings/DevicePage.qml
 +++ printer_ui/printerui/qml/settings/DevicePage.qml
-@@ -3,14 +3,45 @@
+@@ -3,14 +3,46 @@
  import QtQml 2.12
  import UIBase 1.0
  import Printer 1.0
 +import X1PlusNative 1.0
  
++import "../X1Plus.js" as X1Plus
  import "qrc:/uibase/qml/widgets"
  import ".."
 +import "../printer"
@@ -46,7 +47,7 @@
  
      onVisibleChanged: {
          DeviceManager.activeDeviceInfos(DeviceManager.DI_Storage, visible)
-@@ -22,6 +53,7 @@
+@@ -22,6 +54,7 @@
  
      property var infoItems: SimpleItemModel {
          DeviceInfoItem { title: qsTr("Device"); value: build.name
@@ -54,7 +55,7 @@
          }
          DeviceInfoItem { title: qsTr("Language"); value: DeviceManager.languageTitle
              function onClicked() {
-@@ -31,8 +63,8 @@
+@@ -31,8 +64,8 @@
                  choisePad.choiseCallback = function(c) { DeviceManager.languageTitle = c }
                  choisePad.popupFor()
              } }
@@ -65,7 +66,7 @@
              property var onClicked: triggerVersion
          }
          DeviceInfoItem { title: qsTr("Video"); value: models[number]
-@@ -56,79 +88,59 @@
+@@ -56,79 +89,59 @@
                  }
                  choisePad.popupFor()
              } }
@@ -83,7 +84,7 @@
 -//        DeviceInfoItem { title: qsTr("Model Name"); value: build.product }
 -        DeviceInfoItem { title: qsTr("Device info"); value: build.seriaNO
 -            function onClicked() { pageStack.push("DeviceInfoPage.qml") }
-+        DeviceInfoItem { title: qsTr("Screen lock"); value: [qsTr("2min"), qsTr("5min"), qsTr("10min"), qsTr("15min")][DeviceManager.power.mode] + ", " + ["screen saver", "swipe to unlock", "passcode"][DeviceManager.getSetting("cfw_locktype", 0)]
++        DeviceInfoItem { title: qsTr("Screen lock"); value: [qsTr("2min"), qsTr("5min"), qsTr("10min"), qsTr("15min")][DeviceManager.power.mode] + ", " + ["screen saver", "swipe to unlock", "passcode"][X1Plus.Settings.get("lockscreen.mode", 0)]
 +            function onClicked() { pageStack.push("ScreenLockPage.qml") }
          }
 -//        DeviceInfoItem { title: qsTr("Certification"); value: ""
@@ -189,7 +190,7 @@
          var export_ = function(index) {
  //            if (!DeviceManager.exportSystemLog())
  //                return
-@@ -173,30 +185,36 @@
+@@ -173,30 +186,36 @@
                                          onYes: restore
                                      })
          }
@@ -236,7 +237,7 @@
                  anchors.horizontalCenter: parent.horizontalCenter
                  color: Colors.gray_200
                  font: Fonts.body_40
-@@ -206,6 +224,7 @@
+@@ -206,6 +225,7 @@
              ZText {
                  id: sdSpace
                  anchors.top: sdName.bottom
@@ -244,7 +245,7 @@
                  anchors.horizontalCenter: sdName.horizontalCenter
                  color: Colors.font2
                  font: Fonts.body_24
-@@ -215,12 +234,12 @@
+@@ -215,12 +235,12 @@
  
              ZProgressBar {
                  id: sdProgressBar
@@ -260,7 +261,7 @@
                  anchors.horizontalCenter: parent.horizontalCenter
                  backgroundColor: StateColors.get("gray_500")
                  progressColor: Colors.brand
-@@ -229,25 +248,73 @@
+@@ -229,25 +249,73 @@
          }
  
          MarginPanel {
@@ -350,7 +351,7 @@
                  }
              }
          }
-@@ -255,7 +322,7 @@
+@@ -255,7 +323,7 @@
          MarginPanel {
              id: lanOnly
              width: 426
@@ -359,7 +360,7 @@
              anchors.top: sdIdStorage.bottom
              anchors.topMargin: 16
              anchors.left: sdIdStorage.left
-@@ -266,30 +333,45 @@
+@@ -266,30 +334,45 @@
              Text {
                  id: lanOnlyText
                  anchors.top: parent.top
@@ -419,7 +420,7 @@
                                              if (!RecordManager.rtspServerOn) {
                                                  dialogStack.popupDialog(
                                                              "TextConfirm", {
-@@ -302,27 +384,62 @@
+@@ -302,27 +385,62 @@
                                                                  }
                                                              })
                                              }
@@ -491,7 +492,7 @@
                  anchors.left: lanOnlyText.left
                  color: Colors.brand
                  font: Fonts.body_24
-@@ -335,8 +452,7 @@
+@@ -335,8 +453,7 @@
                  height: width
                  radius: width / 2
                  anchors.top: accessCodeText.top
@@ -501,7 +502,7 @@
                  type: ZButtonAppearance.Secondary
                  iconPosition: ZButtonAppearance.Center
                  paddingX: 0
-@@ -362,9 +478,9 @@
+@@ -362,9 +479,9 @@
          }
  
          MarginPanel {
@@ -513,7 +514,7 @@
              anchors.top: lanOnly.bottom
              anchors.topMargin: 16
              anchors.left: lanOnly.left
-@@ -373,28 +489,84 @@
+@@ -373,28 +490,84 @@
              marginColor: "transparent"
  
              Text {
@@ -608,7 +609,7 @@
          }
      }
  
-@@ -404,7 +576,9 @@
+@@ -404,7 +577,9 @@
          anchors.right: parent.right
          anchors.top: parent.top
          anchors.bottom: parent.bottom
@@ -619,7 +620,7 @@
          radius: 15
          color: Colors.gray_600
  
-@@ -581,6 +755,114 @@
+@@ -581,6 +756,114 @@
  
      }
  
@@ -734,7 +735,7 @@
      function setResolution(res)
      {
          if(res === RecordManager.resolution)
-@@ -607,4 +889,41 @@
+@@ -607,4 +890,41 @@
              }
          }
      }

--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
@@ -13,8 +13,8 @@ import ".."
 Rectangle {
     property var locked: false
     property var isEnteringPasscode: false
-    property var passcode: X1Plus.Settings.get("passcode", "")
-    property var locktype: X1Plus.Settings.get("locktype", 0)
+    property var passcode: X1Plus.Settings.get("lockscreen.passcode", "")
+    property var locktype: X1Plus.Settings.get("lockscreen.mode", 0)
     /* 0 = screensaver only, 1 = swipe to unlock, 2 = passcode */
     property var lockImage: X1PlusNative.getenv("EMULATION_WORKAROUNDS") + DeviceManager.getSetting("cfw_lockscreen_image", '/mnt/sdcard/x1plus/lockscreen.png')
     color: Colors.gray_800

--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLock.qml
@@ -16,7 +16,7 @@ Rectangle {
     property var passcode: X1Plus.Settings.get("lockscreen.passcode", "")
     property var locktype: X1Plus.Settings.get("lockscreen.mode", 0)
     /* 0 = screensaver only, 1 = swipe to unlock, 2 = passcode */
-    property var lockImage: X1PlusNative.getenv("EMULATION_WORKAROUNDS") + DeviceManager.getSetting("cfw_lockscreen_image", '/mnt/sdcard/x1plus/lockscreen.png')
+    property var lockImage: X1PlusNative.getenv("EMULATION_WORKAROUNDS") + X1Plus.Settings.get("lockscreen.image", '/mnt/sdcard/x1plus/lockscreen.png')
     color: Colors.gray_800
     visible: locked && locktype != 0
     

--- a/bbl_screen-patch/patches/printerui/qml/settings/ScreenLockPage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/ScreenLockPage.qml
@@ -10,7 +10,7 @@ import "../printer"
 
 Item {
     id: top
-    property var passcode: X1Plus.Settings.get("passcode", "")
+    property var passcode: X1Plus.Settings.get("lockscreen.passcode", "")
 
     MarginPanel {
         id: title
@@ -174,12 +174,12 @@ Item {
             backgroundColor: Colors.gray_500
             width: 300
             model: [qsTr("Screen saver only"), qsTr("Swipe to unlock"), qsTr("Passcode")]
-            currentIndex: X1Plus.Settings.get("locktype", 0)
+            currentIndex: X1Plus.Settings.get("lockscreen.mode", 0)
             Binding on currentIndex {
-                value: X1Plus.Settings.get("locktype", 0)
+                value: X1Plus.Settings.get("lockscreen.mode", 0)
             }
             onChoiseTapped: {
-                X1Plus.Settings.put("locktype", currentIndex);
+                X1Plus.Settings.put("lockscreen.mode", currentIndex);
                 const c = DeviceManager.power.mode; /* sort of janky mechanism to trigger the binding on the parent screen to reload */
                 DeviceManager.power.mode = 3 - c;
                 DeviceManager.power.mode = c;
@@ -271,7 +271,7 @@ Item {
             focusItem: focus
             onFinished: {
                 if (!cancel) {
-                    X1Plus.Settings.put("passcode", number);
+                    X1Plus.Settings.put("lockscreen.passcode", number);
                 }
             }
         }

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
@@ -52,7 +52,7 @@ function _migrate(k, newk) {
     if (v !== null) {
         console.log(`X1Plus.Settings: migrating key ${k} -> ${newk}`);
         put(newk, v);
-        DeviceManager.putSetting(k, null);
+        X1Plus.DeviceManager.putSetting(k, null);
     }
 }
 

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
@@ -68,4 +68,7 @@ function awaken() {
     
     _migrate("cfw_passcode", "lockscreen.passcode");
     _migrate("cfw_locktype", "lockscreen.mode");
+    _migrate("cfw_lockscreen_image", "lockscreen.image");
+    _migrate("cfw_home_image", "homescreen.image");
+    _migrate("cfw_print_image", "homescreen.image.printing");
 }

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
@@ -66,6 +66,6 @@ function awaken() {
     _settings = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/settings", "x1plus.settings", "GetSettings")();
     _PutSettings = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/settings", "x1plus.settings", "PutSettings");
     
-    _migrate("cfw_passcode", "passcode");
-    _migrate("cfw_locktype", "locktype");
+    _migrate("cfw_passcode", "lockscreen.passcode");
+    _migrate("cfw_locktype", "lockscreen.mode");
 }


### PR DESCRIPTION
We decided it is easier to name things with dotted settings.  So we change `locktype` to `lockscreen.mode` and `passcode` to `lockscreen.passcode` (and fix the migration logic associated...).

We also migrate `cfw_lockscreen_image` to `lockscreen.image`, `cfw_home_image` to `homescreen.image`, and `cfw_print_image` to `homescreen.image.printing`.

As a bonus of this now being Dbus connected and binding connected, you can now change the image without restarting bbl_screen.  Try, for instance:

`./x1plus-test-settings.py homescreen.image.printing=/opt/scooter_profile.jpg`

(after putting a picture of my former cat in /opt), or:

`./x1plus-test-settings.py homescreen.image.printing=None`

to return to the default.  The screen will change without a reboot!