### PR TITLE
Add a Klipperscreen-style temperature graph option.

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -11,6 +11,7 @@
 .import "./x1plus/ShaperCalibration.js" as X1PlusShaperCalibration
 .import "./x1plus/DBus.js" as X1PlusDBus
 .import "./x1plus/Settings.js" as X1PlusSettings
+.import "./x1plus/TempGraph.js" as X1PlusTempGraph
 
 /* Back-end model logic for X1Plus's UI
  *
@@ -54,6 +55,8 @@ X1Plus.DBus = X1PlusDBus;
 var DBus = X1PlusDBus;
 X1Plus.Settings = X1PlusSettings;
 var Settings = X1PlusSettings;
+X1Plus.TempGraph = X1PlusTempGraph;
+var TempGraph = X1PlusTempGraph;
 
 Stats.X1Plus = X1Plus;
 DDS.X1Plus = X1Plus;
@@ -62,6 +65,7 @@ ShaperCalibration.X1Plus = X1Plus;
 GpioKeys.X1Plus = X1Plus;
 DBus.X1Plus = X1Plus;
 Settings.X1Plus = X1Plus;
+TempGraph.X1Plus = X1Plus;
 
 var _DdsListener = JSDdsListener.DdsListener;
 var _X1PlusNative = JSX1PlusNative.X1PlusNative;
@@ -151,6 +155,7 @@ function awaken(_DeviceManager, _PrintManager, _PrintTask) {
 	BedMeshCalibration.awaken();
 	ShaperCalibration.awaken();
 	GpioKeys.awaken();
+	TempGraph.awaken();
 }
 
 X1Plus.DBus.registerMethod("ping", (param) => {

--- a/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/Home2Page.qml.patch
@@ -15,17 +15,18 @@
  import "qrc:/uibase/qml/widgets"
  
  Item {
-@@ -17,6 +20,9 @@
+@@ -17,6 +20,10 @@
      property var carouselImages: WebContents.carouselImages2
      property var defaultImage: DeviceManager.getSystemSetting("device/images_path")
      property bool printPrepare: task.state < PrintTask.RUNNING && task.state > PrintTask.IDLE
 +    property var serialNo: DeviceManager.build.seriaNO
 +    property var print_png: X1Plus.Settings.get("homescreen.image.printing", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
 +    property var img_print: X1Plus.fileExists(print_png) ? "file://" + print_png: "qrc:/printerui/image/exhibition1.png"
++    property var is_showing_graph: X1Plus.Settings.get("homescreen.graph.enabled", false)
      property var stateIcons: {
          var icons = []
          if (RecordManager.isTimelapseOn) {
-@@ -297,7 +303,8 @@
+@@ -297,20 +304,28 @@
          topMargin: statusPanel.topMargin
          bottomMargin: statusPanel.bottomMargin
          color: hmsItem.visible ? Colors.gray_700: Colors.gray_600
@@ -33,9 +34,10 @@
 +        
 +        
          ZCarouselView {
++            visible: !is_showing_graph
              anchors.fill: parent
              anchors.margins: 10
-@@ -305,7 +312,7 @@
+             interval: 10000
              orientation: Qt.Vertical
              visible: !hmsItem.visible && !printStep.visible
              model: carouselImages.length === 0
@@ -44,3 +46,14 @@
                     : carouselImages.map(function(i) { return i.imageUrl })
              onModelChanged: {
                  console.log("Home2Page ZCarouselView image model: ", model)
+             }
+         }
++        
++        TempGraph {
++            visible: is_showing_graph
++            anchors.fill: parent
++            anchors.margins: 10
++        }
+ 
+         Item {
+             id: printStep

--- a/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
@@ -27,7 +27,13 @@
  
      MarginPanel {
          id: showPanel
-@@ -30,8 +38,8 @@
+@@ -25,18 +33,23 @@
+         topMargin: 23
+         bottomMargin: 24
+ 
++/*
+         ZCarouselView {
+             anchors.fill: parent
              interval: 10000
              orientation: hmsPanel.visible ? Qt.Vertical : Qt.Horizontal
              model: carouselImages.length === 0
@@ -38,3 +44,12 @@
                     : carouselImages.map(function(i) { return i.imageUrl })
              onModelChanged: {
                  console.log("HomePage ZCarouselView image model: ", model)
+             }
+         }
++*/
++        TempGraph {
++            anchors.fill: parent
++        }
+     }
+ 
+     PrintPanel {

--- a/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/HomePage.qml.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/qml/main/HomePage.qml
 +++ printer_ui/printerui/qml/main/HomePage.qml
-@@ -2,17 +2,25 @@
+@@ -2,17 +2,26 @@
  import QtQuick.Controls 2.12
  import UIBase 1.0
  import Printer 1.0
@@ -21,18 +21,18 @@
 +    property var print_png: X1Plus.Settings.get("homescreen.image.printing", `/mnt/sdcard/x1plus/printers/${serialNo}/images/printing.png`)
 +    property var img_print: X1Plus.fileExists(print_png) ? "file://"+print_png: "qrc:/printerui/image/exhibition1.png"
 +    property var img_home: X1Plus.fileExists(home_png) ? "file://"+home_png: "qrc:/printerui/image/exhibition.png" 
++    property var is_showing_graph: X1Plus.Settings.get("homescreen.graph.enabled", false)
      EventTrack.pageName: "Home"
 +    
 +    
  
      MarginPanel {
          id: showPanel
-@@ -25,18 +33,23 @@
-         topMargin: 23
+@@ -26,17 +35,23 @@
          bottomMargin: 24
  
-+/*
          ZCarouselView {
++            visible: !is_showing_graph
              anchors.fill: parent
              interval: 10000
              orientation: hmsPanel.visible ? Qt.Vertical : Qt.Horizontal
@@ -46,8 +46,9 @@
                  console.log("HomePage ZCarouselView image model: ", model)
              }
          }
-+*/
++
 +        TempGraph {
++            visible: is_showing_graph
 +            anchors.fill: parent
 +        }
      }

--- a/bbl_screen-patch/patches/printerui/qml/printer/TempGraph.qml
+++ b/bbl_screen-patch/patches/printerui/qml/printer/TempGraph.qml
@@ -1,0 +1,197 @@
+import QtQuick 2.0
+import UIBase 1.0
+import Printer 1.0
+import QtQuick.Controls 2.12
+
+import "qrc:/uibase/qml/widgets"
+import ".."
+
+import '../X1Plus.js' as X1Plus
+
+Item {
+    id: tempgraph
+    property var samples: X1Plus.TempGraph.samples()
+    
+    onSamplesChanged: {
+        canvas.requestPaint();
+    }
+    
+    Canvas {
+        id: canvas
+        width: parent.width
+        height: parent.height
+        
+        onPaint: {
+            var XRES = canvas.width;
+            var YRES = canvas.height;
+            var N_SAMPLES = X1Plus.TempGraph.N_SAMPLES;
+            
+            if (width < 500) {
+                /* HMS panel is present */
+                if (N_SAMPLES > 5 * 60) {
+                    N_SAMPLES = 5 * 60;
+                }
+            }
+
+            var WPLOT = XRES - 95;
+            var HPLOT = YRES - 80;
+
+            var MAXT = 325;
+            var MINT = 0;
+
+            var ctx = getContext("2d");
+            ctx.clearRect(0, 0, XRES, YRES);
+
+            const LOG_SKEW = 25; // adjust the knee of the logarithm
+            const k0 = 1.0 / Math.log(N_SAMPLES + LOG_SKEW);
+            const k1 = 1.0 / (1 - Math.log(LOG_SKEW + 1) * k0);
+            function to_xc(sampn) {
+                /* output: len(sampn) - 1 is at 1.0, len(sampn) - N_SAMPLES is at 0.0 */
+                // (1 - (log(N_SAMPLES + LOG_SKEW - x)) / log(N_SAMPLES + LOG_SKEW)) / (1 - log(LOG_SKEW + 1) / log(N_SAMPLES + LOG_SKEW));
+                return (1 - (Math.log(N_SAMPLES + LOG_SKEW - sampn)) * k0) * k1 * WPLOT;
+            }
+            
+            function to_yc(tempc) {
+                return HPLOT - HPLOT / (MAXT - MINT) * (tempc - MINT);
+            }
+            
+            //ctx.fillStyle = 'rgba(66, 68, 65, 1.0)';
+            //ctx.fillRect(0, 0, XRES, YRES);
+            
+            ctx.save();
+            ctx.translate(75, 16);
+
+            // put the text BEFORE we clip
+            function put_xlbl(f, txt) {
+                if (f < 0)
+                    return;
+                ctx.strokeStyle = 'rgba(128, 128, 128, 1.0)';
+                ctx.beginPath();
+                ctx.moveTo(to_xc(f), HPLOT);
+                ctx.lineTo(to_xc(f), HPLOT + 15);
+                ctx.stroke();
+
+                ctx.fillStyle = 'rgba(192, 192, 192, 1.0)';
+                ctx.textBaseline = 'top';
+                ctx.textAlign = 'center';
+                ctx.font = '20px \"HarmonyOS Sans SC\"';
+                ctx.fillText(txt, to_xc(f), HPLOT + 20);
+            }
+            put_xlbl(N_SAMPLES - 10, "-10s")
+            put_xlbl(N_SAMPLES - 30, "-30s")
+            put_xlbl(N_SAMPLES - 60, "-1min")
+            put_xlbl(N_SAMPLES - 120, "-2min")
+            put_xlbl(N_SAMPLES - 5*60, "-5min")
+            put_xlbl(N_SAMPLES - 10*60, "-10min")
+            put_xlbl(N_SAMPLES - 15*60, "-15min")
+
+            function put_ylbl(db) {
+                ctx.fillStyle = 'rgba(192, 192, 192, 1.0)';
+                ctx.textBaseline = 'middle';
+                ctx.textAlign = 'right';
+                ctx.font = '20px \"HarmonyOS Sans SC\"';
+                ctx.fillText(i + "°C", -10, to_yc(db));
+            }
+            for (var i = MINT; i <= MAXT; i += 50) {
+                put_ylbl(i);
+            }
+
+            ctx.beginPath();
+            /* QML canvas2d does not have ctx.roundRect, so we suffer */
+            const RADIUS = 25;
+            ctx.moveTo(RADIUS, 0);
+            ctx.lineTo(WPLOT - RADIUS, 0);
+            ctx.arc(WPLOT - RADIUS, RADIUS, RADIUS, -Math.PI / 2, 0);
+            ctx.lineTo(WPLOT, HPLOT - RADIUS);
+            ctx.arc(WPLOT - RADIUS, HPLOT - RADIUS, RADIUS, 0, Math.PI / 2);
+            ctx.lineTo(RADIUS, HPLOT);
+            ctx.arc(RADIUS, HPLOT - RADIUS, RADIUS, Math.PI / 2, Math.PI);
+            ctx.lineTo(0, RADIUS);
+            ctx.arc(RADIUS, RADIUS, RADIUS, Math.PI, 3 * Math.PI / 2);
+            ctx.clip();
+            
+            ctx.fillStyle = 'rgba(40, 40, 40, 1.0)';
+            ctx.fill();
+
+            // plot a graticule
+            ctx.strokeStyle = 'rgba(80, 80, 80, 1.0)';
+            ctx.beginPath();
+            for (var i = MINT; i <= MAXT; i += 50) {
+                ctx.moveTo(0, to_yc(i));
+                ctx.lineTo(WPLOT, to_yc(i));
+            }
+            ctx.stroke();
+
+            ctx.strokeStyle = 'rgba(80, 80, 80, 1.0)';
+            ctx.beginPath();
+            var breaks = [-60, -2*60, -3*60, -4*60, -5*60, -6*60, -7*60, -8*60, -9*60, -10*60];
+            for (var i in breaks) {
+                ctx.moveTo(to_xc(breaks[i] + N_SAMPLES), 0);
+                ctx.lineTo(to_xc(breaks[i] + N_SAMPLES), HPLOT);
+            }
+            ctx.stroke();
+
+            var minsamp = N_SAMPLES - samples.length;
+            if (minsamp < 0)
+                minsamp = 0;
+
+            var sxs = [];
+            for (var i = minsamp; i < samples.length; i++) {
+                sxs.push(to_xc(i + N_SAMPLES - samples.length));
+            }
+
+            /* plot nozzle setpoint */
+            ctx.fillStyle = 'rgba(192, 128, 128, 0.2)';
+            ctx.lineWidth = 3;
+            ctx.beginPath();
+            ctx.moveTo(sxs[minsamp], to_yc(MINT));
+            for (var i = minsamp; i < samples.length; i++) {
+                ctx.lineTo(sxs[i], to_yc(samples[i][1]));
+            }
+            ctx.lineTo(sxs[samples.length-1], to_yc(MINT));
+            ctx.lineTo(sxs[minsamp], to_yc(MINT));
+            
+            ctx.fill();
+
+            /* plot bed setpoint */
+            ctx.fillStyle = 'rgba(128, 128, 192, 0.2)';
+            ctx.lineWidth = 3;
+            ctx.beginPath();
+            ctx.moveTo(sxs[minsamp], to_yc(MINT));
+            for (var i = minsamp; i < samples.length; i++) {
+                ctx.lineTo(sxs[i], to_yc(samples[i][3]));
+            }
+            ctx.lineTo(sxs[samples.length-1], to_yc(MINT));
+            ctx.lineTo(sxs[minsamp], to_yc(MINT));
+            ctx.fill();
+            
+            /* plot nozzle temps */
+            ctx.strokeStyle = 'rgba(255, 192, 192, 0.7)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            for (var i = minsamp; i < samples.length; i++) {
+                ctx.lineTo(sxs[i], to_yc(samples[i][minsamp]));
+            }
+            ctx.stroke();
+
+            /* plot bed temps */
+            ctx.strokeStyle = 'rgba(192, 192, 255, 0.7)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            for (var i = minsamp; i < samples.length; i++) {
+                ctx.lineTo(sxs[i], to_yc(samples[i][2]));
+            }
+            ctx.stroke();
+
+            /* plot chamber temps */
+            ctx.strokeStyle = 'rgba(192, 255, 192, 0.7)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            for (var i = minsamp; i < samples.length; i++) {
+                ctx.lineTo(sxs[i], to_yc(samples[i][4]));
+            }
+            ctx.stroke();
+            ctx.restore();
+        }
+    }
+}

--- a/bbl_screen-patch/patches/printerui/qml/printer/TempGraph.qml
+++ b/bbl_screen-patch/patches/printerui/qml/printer/TempGraph.qml
@@ -13,7 +13,21 @@ Item {
     property var samples: X1Plus.TempGraph.samples()
     
     onSamplesChanged: {
-        canvas.requestPaint();
+        if (visible) {
+            canvas.requestPaint();
+        }
+    }
+    
+    onVisibleChanged: {
+        if (visible) {
+            canvas.requestPaint();
+        }
+    }
+    
+    onWidthChanged: {
+        if (visible) {
+            canvas.requestPaint();
+        }
     }
     
     Canvas {
@@ -131,7 +145,7 @@ Item {
             }
             ctx.stroke();
 
-            var minsamp = N_SAMPLES - samples.length;
+            var minsamp = samples.length - N_SAMPLES;
             if (minsamp < 0)
                 minsamp = 0;
 

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/TempGraph.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/TempGraph.js
@@ -1,0 +1,37 @@
+.pragma library
+.import DdsListener 1.0 as JSDdsListener
+.import X1PlusNative 1.0 as JSX1PlusNative
+.import "Binding.js" as Binding
+
+var X1Plus = null;
+
+const N_SAMPLES = 15 * 60;
+
+/* sample format is [ nozzletemp, nozzleset, bedtemp, bedset, chambertemp ] */
+var [samples, onSamplesChanged, _setSamples] = Binding.makeBinding([]);
+
+var _sampleTimer = Binding.makeTimer();
+_sampleTimer.repeat = true;
+_sampleTimer.interval = 1000;
+_sampleTimer.triggered.connect(function() {
+    var _samples = samples();
+    if (_samples.length == N_SAMPLES) {
+        _samples.shift();
+    }
+    _samples.push([
+        X1Plus.PrintManager.heaters.hotend.currentTemp,
+        X1Plus.PrintManager.heaters.hotend.targetTemp,
+        X1Plus.PrintManager.heaters.heatbed.currentTemp,
+        X1Plus.PrintManager.heaters.heatbed.targetTemp,
+        X1Plus.PrintManager.heaters.chamber.currentTemp,
+    ]);
+    X1Plus.saveJson("/tmp/temperaturelog.json", _samples);
+    _setSamples(_samples);
+});
+
+function awaken() {
+    var loaded = X1Plus.loadJson("/tmp/temperaturelog.json");
+    if (loaded)
+        _setSamples(loaded);
+    _sampleTimer.start();
+}

--- a/bbl_screen-patch/patches/root.qrc.patch
+++ b/bbl_screen-patch/patches/root.qrc.patch
@@ -73,11 +73,12 @@
  <file>printerui/qml/printer/AMSUseBootPage.qml</file>
  <file>printerui/qml/printer/AdjustPage.qml</file>
  <file>printerui/qml/printer/AutoRefillPage.qml</file>
-@@ -197,18 +237,22 @@
+@@ -197,18 +237,23 @@
  <file>printerui/qml/printer/PrintSkipPage.qml</file>
  <file>printerui/qml/printer/Sector.qml</file>
  <file>printerui/qml/printer/SelfTestPage.qml</file>
 -<file>printerui/qml/printer/UtilitiesPage.qml</file>
++<file>printerui/qml/printer/TempGraph.qml</file>
 +<file>printerui/qml/printer/VibrationComp.qml</file>
 +<file>printerui/qml/printer/VibrationCompPlotter.qml</file>
  <file>printerui/qml/settings/AccountPage.qml</file>
@@ -97,7 +98,7 @@
  <file>printerui/qml/settings/InputPage.qml</file>
  <file>printerui/qml/settings/MaintenancePage.qml</file>
  <file>printerui/qml/settings/NetParaSetPage.qml</file>
-@@ -217,9 +261,13 @@
+@@ -217,9 +262,13 @@
  <file>printerui/qml/settings/RegionItem.qml</file>
  <file>printerui/qml/settings/ReleaseNotePage.qml</file>
  <file>printerui/qml/settings/SensorPage.qml</file>
@@ -112,7 +113,7 @@
  <file>printerui/qml/settings/WifiListPage.qml</file>
  <file>printerui/qml/settings/WifiSetupPage.qml</file>
  <file>printerui/qml/wizard/Calibrate1Page.qml</file>
-@@ -235,12 +283,27 @@
+@@ -235,12 +284,28 @@
  <file>printerui/qml/wizard/TermsPage.qml</file>
  <file>printerui/qml/wizard/WelcomePage.qml</file>
  <file>printerui/qml/wizard/WizardPage.qml</file>
@@ -130,6 +131,7 @@
 +<file>printerui/qml/x1plus/Settings.js</file>
 +<file>printerui/qml/x1plus/ShaperCalibration.js</file>
 +<file>printerui/qml/x1plus/Stats.js</file>
++<file>printerui/qml/x1plus/TempGraph.js</file>
  <file>printerui/text/error_texts.de.json</file>
  <file>printerui/text/error_texts.en.json</file>
  <file>printerui/text/error_texts.es.json</file>
@@ -140,7 +142,7 @@
  <file>printerui/text/error_texts.sv.json</file>
  <file>printerui/text/error_texts.zh-cn.json</file>
  <file>printerui/text/error_texts.zh-tw.json</file>
-@@ -259,6 +322,7 @@
+@@ -259,6 +324,7 @@
  <file>printerui/text/hms_texts.fr.json</file>
  <file>printerui/text/hms_texts.ja.json</file>
  <file>printerui/text/hms_texts.nl.json</file>
@@ -148,7 +150,7 @@
  <file>printerui/text/hms_texts.sv.json</file>
  <file>printerui/text/hms_texts.zh-cn.json</file>
  <file>printerui/text/hms_texts.zh-tw.json</file>
-@@ -295,3 +359,4 @@
+@@ -295,3 +361,4 @@
  <file>printerui/text/terms.zh-cn.txt</file>
  <file>qt-project.org/imports/QtQuick/VirtualKeyboard/Styles/bbl/style.qml</file>
  </qresource></RCC>


### PR DESCRIPTION
Adds a temperature graph to the home screen, configurable with the `homescreen.graph.enabled` setting.  Time scale is logarithmic, with much more visual precision available in the most recent minute, transitioning to a 5-minute or 15-minute trendline.

![image](https://github.com/X1Plus/X1Plus/assets/87427/a84fc888-4ae0-4e20-81c2-599f51e8ac60)

Future work would be to also plot fan speeds, print events, average feed rates, etc; for now, this is fixed function of nozzle / bed / chamber temp.

Associated with #30, but there still needs to be UI work done to build a toggle for this before we can close that.
