### PR TITLE
Update base firmware to 01.08.00.00.

### DIFF
--- a/firmwares/Makefile
+++ b/firmwares/Makefile
@@ -20,6 +20,11 @@ define fetchimage =
 	../scripts/repack_update.py $(3) $(4)
 endef
 
+define fetchimage_fullurl =
+	wget -q -N -c "$(1)/$(2)"
+	../scripts/repack_update.py $(2) $(3)
+endef
+
 00.00.19.15.squashfs:
 	$(call fetchimage,01.05.01.00,,update-v00.00.19.15-20230423131316_product.img.zip.sig,$@)
 
@@ -49,3 +54,6 @@ endef
 
 00.00.32.17.squashfs:
 	$(call fetchimage,01.07.03.05,79a426f63e/,update-v00.00.32.17-20240409222723_product.img.zip.sig,$@)
+
+00.00.32.18.squashfs:
+	$(call fetchimage_fullurl,https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25,update-v00.00.32.18-20240422102213_product.img.zip.sig,$@)

--- a/images/cfw.py
+++ b/images/cfw.py
@@ -111,6 +111,10 @@ whiteout('/lib/optee_armtz/e6a33ed4-562b-463a-bb7e-ff5e15a493c8.ta')
 whiteout('/lib/optee_armtz/f157cda0-550c-11e5-a6fa-0002a5d5c51b.ta')
 whiteout('/lib/optee_armtz/ffd2bded-ab7d-4988-95ee-e4962fff7154.ta')
 
+whiteout('/usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt')
+whiteout('/etc/ssl/certs/DST_Root_CA_X3.pem')
+whiteout('/etc/ssl/certs/2e5ac55d.0')
+
 globfiles("cfw/etc", "/etc")
 globfiles("cfw/usr", "/usr", eatlinks = [ 'bin/jq' ])
 globfiles("cfw/lib", "/lib")

--- a/images/cfw/opt/cfwversions.json
+++ b/images/cfw/opt/cfwversions.json
@@ -1,13 +1,13 @@
 {
     "cfw": { "dialogName": "X1Plus firmware", "version": "[version error]", "alwaysNoUpgrade": true, "noUpgrade": "COPY_NEW_X1P" },
-    "ota": { "dialogName": "Bambu Lab base firmware", "version": "01.07.03.05", "alwaysNoUpgrade": true, "noUpgrade": "COPY_NEW_X1P" },
-    "rv1126": { "version": "00.00.32.17", "noUpgrade": "WRONG_BASE_VERSION" },
+    "ota": { "dialogName": "Bambu Lab base firmware", "version": "01.08.00.00", "alwaysNoUpgrade": true, "noUpgrade": "COPY_NEW_X1P" },
+    "rv1126": { "version": "00.00.32.18", "noUpgrade": "WRONG_BASE_VERSION" },
     "th": { "version": "00.00.07.12", "paths": {
-        "th07": { "url": "https://public-cdn.bambulab.com/upgrade/device/BL-P001/01.07.02.00/product/62201b7e2c/th_rev7-firmware-v00.00.07.12-20231031102713_product.bin.sig", "md5": "20eacbc29a81fa42daf93a8693cbc113" },
-        "th09": { "url": "https://public-cdn.bambulab.com/upgrade/device/BL-P001/01.07.02.00/product/62201b7e2c/th_rev9-firmware-v00.00.07.12-20231031102810_product.bin.sig", "md5": "7549a5096c530a1ba43e92f4ad0e3261" }
+        "th07": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25/th_rev7-firmware-v00.00.07.12-20231031102713_product.bin.sig", "md5": "20eacbc29a81fa42daf93a8693cbc113" },
+        "th09": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25/th_rev9-firmware-v00.00.07.12-20231031102810_product.bin.sig", "md5": "7549a5096c530a1ba43e92f4ad0e3261" }
     } },
-    "mc": { "version": "00.00.27.23", "paths": {
-        "mc07": { "url": "https://public-cdn.bambulab.com/upgrade/device/BL-P001/01.07.03.05/product/79a426f63e/mc_rev7-firmware-v00.00.27.23-20240416032520_product.bin.sig", "md5": "8c17e60555d6a9e54a1175c6f570a2b3" }
+    "mc": { "version": "00.00.27.26", "paths": {
+        "mc07": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25/mc_rev7-firmware-v00.00.27.26-20240422094119_product.bin.sig", "md5": "44b644103fde8f38f1e4db28c0fd61e0" }
     } },
     "xm": { "version": "00.01.02.02", "paths": {
         "": { "url": "https://public-cdn.bambulab.com/upgrade/device/BL-P001/xm/00.01.02.02/product/xm_v00.01.02.02-20230328103404_product.rknn.sig", "md5": "50c4487de44fec31d63dd8f8c3464446" }

--- a/installer/base.json
+++ b/installer/base.json
@@ -1,10 +1,10 @@
 {
-    "version": "01.07.03.00",
-    "ap": "00.00.32.17",
-    "updateUrl": "https://public-cdn.bambulab.com/upgrade/device/BL-P001/01.07.03.05/product/79a426f63e/update-v00.00.32.17-20240409222723_product.img.zip.sig",
-    "updateName": "update-v00.00.32.17-20240409222723_product.img.zip.sig",
-    "updateMd5": "d207b19601befe17e49eee3d2d804593",
-    "squashfsName": "00.00.32.17.squashfs",
-    "squashfsMd5": "29d068d4b0dacab7cbac5b53e20febf7",
-    "mtime": 1712648206
+    "version": "01.08.00.00",
+    "ap": "00.00.32.18",
+    "updateUrl": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25/update-v00.00.32.18-20240422102213_product.img.zip.sig",
+    "updateName": "update-v00.00.32.18-20240422102213_product.img.zip.sig",
+    "updateMd5": "af197ded334dea01e5ce95ee56155e0a",
+    "squashfsName": "00.00.32.18.squashfs",
+    "squashfsMd5": "11153f2d890fc774687c960c96b1fa77",
+    "mtime": 1715067071
 }

--- a/installer/install.py
+++ b/installer/install.py
@@ -282,7 +282,8 @@ if not exists_with_md5(basefw_squashfs_path, basefw_squashfs_md5):
         try:
             os.makedirs(os.path.dirname(basefw_update_path), exist_ok = True)
             report_interim_progress("Connecting...")
-            with urllib.request.urlopen(basefw_update_url, capath="/etc/ssl/certs") as resp, \
+            req = urllib.request.Request(basefw_update_url, data = None, headers = { 'User-Agent': f'X1Plus/{cfw_version}' })
+            with urllib.request.urlopen(req, capath="/etc/ssl/certs") as resp, \
                  open(basefw_update_path, "wb") as f:
                 totlen = resp.getheader('content-length')
                 curlen = 0


### PR DESCRIPTION
Updates the base firmware to 01.08.00.00.  In so doing, we make two other changes required to make 01.08.00.00 work properly:

* When downloading in the installer, we identify ourselves as X1Plus, rather than urllib, because urllib is blocklisted on bblmw.com.  And anyway, we should do that.
* Because bblmw.com uses Let's Encrypt instead of Google SSL, it can break Qt's SSL implementation.  Remove an ancient expired Let's Encrypt certificate to fix that.  For bonus points, this also fixes a bug that is almost certainly present in OEM where avatars may not download properly since they were migrated to bblmw.com.

Fixes #242.