### PR TITLE
QProcess class for subprocesses in QML

### DIFF
--- a/bbl_screen-patch/interpose.cpp
+++ b/bbl_screen-patch/interpose.cpp
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <QtCore/QObject>
 #include <QtCore/QSettings>
+#include <QtCore/QProcess>
+#include <QtCore/QVariantList>
 #include <QtQml/qqml.h>
 #include <QtQml/qjsengine.h>
 #include <QtQml/qjsvalue.h>
@@ -753,7 +755,7 @@ public:
                 QProcess::kill();
             }
         }
-    }
+    }  
     Q_DISABLE_COPY(Process);
 };
 
@@ -932,6 +934,7 @@ extern "C" void __attribute__ ((constructor)) init() {
         needs_emulation_workarounds = 1;
     setenv("QML_XHR_ALLOW_FILE_READ", "1", 1); // Tell QML that it's ok to let us read files from inside XHR land.
     setenv("QML_XHR_ALLOW_FILE_WRITE", "1", 1); // Tell QML that it's ok to let us write files from inside XHR land.
+    qmlRegisterType<Process>("Process", 1, 0, "Process");
     qmlRegisterSingletonType("X1PlusNative", 1, 0, "X1PlusNative", [](QQmlEngine *engine, QJSEngine *scriptEngine) -> QJSValue {
         Q_UNUSED(engine)
 

--- a/bbl_screen-patch/interpose.cpp
+++ b/bbl_screen-patch/interpose.cpp
@@ -726,6 +726,37 @@ SWIZZLE(void, _ZN5BDbus4NodeC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESa
 
 #endif
 
+/* QProcess class for running shell from QML a bit more reliably */
+class Process : public QProcess
+{
+    Q_OBJECT
+public:
+    explicit Process(QObject* parent = nullptr) : QProcess(parent) {
+        setProcessChannelMode(QProcess::MergedChannels);
+    }
+
+    Q_INVOKABLE void start(const QString& program, const QVariantList& arguments = QVariantList()) {
+        QStringList args;
+        for (const auto& arg : arguments) {
+            args << arg.toString();
+        }
+        QProcess::start(program, args);
+    }
+
+    Q_INVOKABLE QByteArray readAll() { return QProcess::readAll(); }
+    Q_INVOKABLE QByteArray readLine() { return QProcess::readLine(); }
+
+    Q_INVOKABLE void terminate() {
+        if (state() == QProcess::Running) {
+            QProcess::terminate();
+            if (!waitForFinished(3000)) {
+                QProcess::kill();
+            }
+        }
+    }
+    Q_DISABLE_COPY(Process);
+};
+
 /*** Tricks to override the backlight.  See X1PlusNative.updateBacklight above. ***/
 
 FILE *backlight_fp = NULL;

--- a/bbl_screen-patch/interpose.cpp
+++ b/bbl_screen-patch/interpose.cpp
@@ -729,11 +729,11 @@ SWIZZLE(void, _ZN5BDbus4NodeC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESa
 #endif
 
 /* QProcess class for running shell from QML a bit more reliably */
-class Process : public QProcess
+class X1PlusProcess : public QProcess
 {
     Q_OBJECT
 public:
-    explicit Process(QObject* parent = nullptr) : QProcess(parent) {
+    explicit X1PlusProcess(QObject* parent = nullptr) : QProcess(parent) {
         setProcessChannelMode(QProcess::MergedChannels);
     }
 
@@ -748,6 +748,11 @@ public:
     Q_INVOKABLE QByteArray readAll() { return QProcess::readAll(); }
     Q_INVOKABLE QByteArray readLine() { return QProcess::readLine(); }
 
+    /* Write to an active process */
+    Q_INVOKABLE qint64 write( const QString& data ){
+        return QProcess::write( qPrintable( data ) );
+    }
+    
     Q_INVOKABLE void terminate() {
         if (state() == QProcess::Running) {
             QProcess::terminate();
@@ -756,7 +761,9 @@ public:
             }
         }
     }  
-    Q_DISABLE_COPY(Process);
+
+private:
+    Q_DISABLE_COPY(X1PlusProcess);
 };
 
 /*** Tricks to override the backlight.  See X1PlusNative.updateBacklight above. ***/
@@ -934,7 +941,7 @@ extern "C" void __attribute__ ((constructor)) init() {
         needs_emulation_workarounds = 1;
     setenv("QML_XHR_ALLOW_FILE_READ", "1", 1); // Tell QML that it's ok to let us read files from inside XHR land.
     setenv("QML_XHR_ALLOW_FILE_WRITE", "1", 1); // Tell QML that it's ok to let us write files from inside XHR land.
-    qmlRegisterType<Process>("Process", 1, 0, "Process");
+    qmlRegisterType<X1PlusProcess>("X1PlusProcess", 1, 0, "X1PlusProcess");
     qmlRegisterSingletonType("X1PlusNative", 1, 0, "X1PlusNative", [](QQmlEngine *engine, QJSEngine *scriptEngine) -> QJSValue {
         Q_UNUSED(engine)
 


### PR DESCRIPTION
Defines QProcess class in interpose.cpp to use in QML. 

Many of the methods are built into QProcess, so I have left the class very bare bones. We still have access to methods for setting environmental variables, working directory, etc. in addition to signals emitted with error codes and process status. 

Here is an example of using it to untar an archive:
```
import Process 1.0

extract.start("tar", ["-xvf", "cfw.x1p"])

 Process {
    id: extract
    property string output: ""
    onStarted: console.log("started")
    onFinished: console.log("Process finished with exit code:", exitCode, "and status:", exitStatus)
    onErrorOccurred: console.log("Error Ocuured: ", error)

    onReadyReadStandardOutput: {
        output = extract.readAll();
        console.log(output);
    }
}
```

This is for use anywhere in QML that requires efficient handling of shell commands and/or python. One idea I've already tested and have working on another branch is running ConsolePage.qml commands with this (although long term, I still want a real terminal emulator). 