### PR TITLE
feat: breakout and improve ota.json generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 localconfig.mk
 installer/info.json
+bbl_screen-patch/interpose.moc.h
 
 # Build artifacts
 *.x1p

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(CFWVERSION).x1p: images initramfs bbl_screen-patch
 	scripts/mkx1p.py $@
 
 ota.json: $(CFWVERSION).x1p
-	scripts/mkotajson $< $@
+	scripts/mkotajson.py $< $@
 
 bbl_screen-patch: firmwares
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ define make =
 	$(MAKE) -C $(1) $(MAKEFLAGS) FIRMWARE=$(FIRMWARE) $(2)
 endef
 
-all: $(CFWVERSION).x1p
+all: $(CFWVERSION).x1p ota.json
 	make -C installer-clientside/stage1
 
 # needs:
@@ -41,7 +41,9 @@ all: $(CFWVERSION).x1p
 #   images/cfw.squashfs
 $(CFWVERSION).x1p: images initramfs bbl_screen-patch
 	scripts/mkx1p.py $@
-	scripts/mkotajson.py
+
+ota.json: $(CFWVERSION).x1p
+	scripts/mkotajson $< $@
 
 bbl_screen-patch: firmwares
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ all: $(CFWVERSION).x1p
 #   images/cfw.squashfs
 $(CFWVERSION).x1p: images initramfs bbl_screen-patch
 	scripts/mkx1p.py $@
+	scripts/mkotajson.py
 
 bbl_screen-patch: firmwares
 

--- a/scripts/mkinfojson.py
+++ b/scripts/mkinfojson.py
@@ -36,18 +36,6 @@ else:
     cfwVersion = describe[0].split('/')[1] 
     # date of the tag
     cfwdate = subprocess.run(["git", "tag", "-l", describe[0], "--format=%(taggerdate:format:%Y-%m-%d)"], capture_output=True, check=True, cwd=ROOTPATH).stdout.decode().strip()
-    # Generate OTA file
-    json.dump(
-        {
-            "cfwVersion": cfwVersion,
-            "date": cfwdate,
-            "buildTimestamp": timestamp,
-            "notes": tagnotes,
-            "url": f"https://github.com/X1Plus/X1Plus/releases/download/x1plus%2F{cfwVersion}/{cfwVersion}.x1p"
-        },
-        open(f"{ROOTPATH}/ota.json", "w"),
-        indent = 4,
-    )
 
 # Dump installer json for x1p
 json.dump(

--- a/scripts/mkotajson.py
+++ b/scripts/mkotajson.py
@@ -1,37 +1,30 @@
 #!/usr/bin/env python3
 
+import sys
 import os
 import json
 import hashlib
+import zipfile
 
-ROOTPATH = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
-
-# Load info.json
-try:
-    INFO = json.load(open(f"{ROOTPATH}/installer/info.json", "r"))
-except Exception as e:
-    print(f"Error loading info.json, has mkinfojson.sh ran yet?! Error of: {e}")
-    raise
+with zipfile.ZipFile(sys.argv[1], 'r') as zf:
+    with zf.open('info.json') as f:
+        info = json.load(f)
 
 # MD5sum our OTA file
-try:
-    OTA_MD5 = hashlib.md5(open(f"{ROOTPATH}/{INFO['cfwVersion']}.x1p",'rb').read()).hexdigest()
-except Exception as e:
-    print(f"Error loading {INFO.cfwVersion}.x1p, did the x1p build correctly?! Error of: {e}")
-    raise
+ota_md5 = hashlib.md5(open(sys.argv[1], 'rb').read()).hexdigest()
 
 # Generate OTA file
 json.dump(
     {
-        "cfwVersion": INFO['cfwVersion'],
-        "date": INFO['date'],
-        "buildTimestamp": INFO['buildTimestamp'],
-        "notes": INFO['notes'],
-        "ota_url": f"https://github.com/X1Plus/X1Plus/releases/download/x1plus%2F{INFO['cfwVersion']}/{INFO['cfwVersion']}.x1p",
-        "ota_md5": OTA_MD5,
-        "base_update_url": INFO['base']['updateUrl'],
-        "base_update_md5": INFO['base']['updateMd5'],
+        "cfwVersion": info['cfwVersion'],
+        "date": info['date'],
+        "buildTimestamp": info['buildTimestamp'],
+        "notes": info['notes'],
+        "ota_url": f"https://github.com/X1Plus/X1Plus/releases/download/x1plus%2F{info['cfwVersion']}/{info['cfwVersion']}.x1p",
+        "ota_md5": ota_md5,
+        "base_update_url": info['base']['updateUrl'],
+        "base_update_md5": info['base']['updateMd5'],
     },
-    open(f"{ROOTPATH}/ota.json", "w"),
+    open(sys.argv[2], "w"),
     indent = 4,
 )

--- a/scripts/mkotajson.py
+++ b/scripts/mkotajson.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import hashlib
+
+ROOTPATH = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+# Load info.json
+try:
+    INFO = json.load(open(f"{ROOTPATH}/installer/info.json", "r"))
+except Exception as e:
+    print(f"Error loading info.json, has mkinfojson.sh ran yet?! Error of: {e}")
+    raise
+
+# MD5sum our OTA file
+try:
+    OTA_MD5 = hashlib.md5(open(f"{ROOTPATH}/{INFO['cfwVersion']}.x1p",'rb').read()).hexdigest()
+except Exception as e:
+    print(f"Error loading {INFO.cfwVersion}.x1p, did the x1p build correctly?! Error of: {e}")
+    raise
+
+# Generate OTA file
+json.dump(
+    {
+        "cfwVersion": INFO['cfwVersion'],
+        "date": INFO['date'],
+        "buildTimestamp": INFO['buildTimestamp'],
+        "notes": INFO['notes'],
+        "ota_url": f"https://github.com/X1Plus/X1Plus/releases/download/x1plus%2F{INFO['cfwVersion']}/{INFO['cfwVersion']}.x1p",
+        "ota_md5": OTA_MD5,
+        "base_update_url": INFO['base']['updateUrl'],
+        "base_update_md5": INFO['base']['updateMd5'],
+    },
+    open(f"{ROOTPATH}/ota.json", "w"),
+    indent = 4,
+)


### PR DESCRIPTION
* Make our ota.json generation be the final step, so we can include the file's MD5 for verification
* Also make sure the base FW info is attached, so our OTA engine can pull this down before we get to bbl_screen
* Also bring back gitignore for interpose.moc.h cuz it got lost somehow. :(