### PR TITLE
teach x1plusd.ota to download OTA images

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
@@ -117,7 +117,7 @@ class OTAService(X1PlusDBusService):
         await self.x1psettings.put('ota.filename', os.path.split(self.last_check_response['ota_url'])[-1])
         if not x1plus.utils.is_emulating():
             os.system("sync; sync; reboot")
-            # we ought never return from this!
+            return {"status": "rebooting"}
         else:
             return {"status": "ok"}
 

--- a/images/cfw/usr/etc/conf/service_list.list
+++ b/images/cfw/usr/etc/conf/service_list.list
@@ -28,5 +28,5 @@ vsftpd                      /etc/init.d/S85vsftpd start
 /usr/bin/bbl_storage        /etc/init.d/S81bbl_storage start
 /opt/x1plus/bin/sd_watchdog /etc/init.d/S01sd_watchdog start
 x1plus.services.gpiokeys    /etc/init.d/S82gpiokeys start
-x1plus.services.x1plusd     /etc/init.d/S72x1plusd start
+x1plus.services.x1plusd.__main__ /etc/init.d/S72x1plusd start
 x1plus.services.syslog_shim /etc/init.d/S93syslog_shim start


### PR DESCRIPTION
In combination with #260, x1plusd can now download and install an OTA of its own.  After installing this version (including the kexec_ui changes from #260), try something like:

```
[root@BL-P001-sdcard:~]# x1plus-test-settings.py ota.enabled=True
[root@BL-P001-sdcard:~]# x1plus-test-settings.py ota.json_url=https://moroso.emarhavil.com/~joshua/x1ota/ota.json
[root@BL-P001-sdcard:~]# dbus-send --system --print-reply --dest=x1plus.x1plusd /x1plus/ota x1plus.ota.GetStatus string:'{}'
[root@BL-P001-sdcard:~]# dbus-send --system --print-reply --dest=x1plus.x1plusd /x1plus/ota x1plus.ota.Download string:'{"base_firmware": true}'
[root@BL-P001-sdcard:~]# dbus-send --system --print-reply --dest=x1plus.x1plusd /x1plus/ota x1plus.ota.GetStatus string:'{}'
(... repeat until status is IDLE again and both ota_is_downloaded and ota_base_is_downloaded ...)
[root@BL-P001-sdcard:~]# dbus-send --system --print-reply --dest=x1plus.x1plusd /x1plus/ota x1plus.ota.Update string:'{}'
```