### PR TITLE
x1plus/DBus: make sure to generate valid DBus messages even if passed no args

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
@@ -76,6 +76,8 @@ function proxyFunction(busName, objName, interface, method) {
         _proxies[busName][objName] = _DBusListener.createProxy(busName, objName);
     }
     return (j) => {
+        if (j === undefined)
+            j = null;
         var s = _proxies[busName][objName].callMethod(interface, method, JSON.stringify(j));
         return JSON.parse(s);
     };


### PR DESCRIPTION
otherwise, bbl_screen would choke on the initial GetSettings() call (it would pass 'undefined' up to DBus, rather than 'null'; x1plusd would fail to parse it, and return an error; and then bbl_screen would choke on the returned error code and fail to continue executing