### PR TITLE
UI for OTA updates in printer_ui

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -12,6 +12,7 @@
 .import "./x1plus/DBus.js" as X1PlusDBus
 .import "./x1plus/Settings.js" as X1PlusSettings
 .import "./x1plus/TempGraph.js" as X1PlusTempGraph
+.import "./x1plus/OTA.js" as X1PlusOTA
 
 /* Back-end model logic for X1Plus's UI
  *
@@ -57,6 +58,8 @@ X1Plus.Settings = X1PlusSettings;
 var Settings = X1PlusSettings;
 X1Plus.TempGraph = X1PlusTempGraph;
 var TempGraph = X1PlusTempGraph;
+X1Plus.OTA = X1PlusOTA;
+var OTA = X1PlusOTA;
 
 Stats.X1Plus = X1Plus;
 DDS.X1Plus = X1Plus;
@@ -66,6 +69,7 @@ GpioKeys.X1Plus = X1Plus;
 DBus.X1Plus = X1Plus;
 Settings.X1Plus = X1Plus;
 TempGraph.X1Plus = X1Plus;
+OTA.X1Plus = X1Plus;
 
 var _DdsListener = JSDdsListener.DdsListener;
 var _X1PlusNative = JSX1PlusNative.X1PlusNative;
@@ -152,6 +156,7 @@ function awaken(_DeviceManager, _PrintManager, _PrintTask) {
 	X1Plus.printerConfigDir = printerConfigDir = `/mnt/sdcard/x1plus/printers/${X1Plus.DeviceManager.build.seriaNO}`;
 	_X1PlusNative.system("mkdir -p " + _X1PlusNative.getenv("EMULATION_WORKAROUNDS") + printerConfigDir);
 	Settings.awaken();
+	OTA.awaken();
 	BedMeshCalibration.awaken();
 	ShaperCalibration.awaken();
 	GpioKeys.awaken();

--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -161,6 +161,7 @@ function awaken(_DeviceManager, _PrintManager, _PrintTask) {
 	ShaperCalibration.awaken();
 	GpioKeys.awaken();
 	TempGraph.awaken();
+	console.log("X1Plus.js is awake");
 }
 
 X1Plus.DBus.registerMethod("ping", (param) => {

--- a/bbl_screen-patch/patches/printerui/qml/main/SettingsPage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/main/SettingsPage.qml.patch
@@ -7,7 +7,7 @@
 -    dots: [false, (updater.hasNewVersion || updater.consistency), false, maintain.carbon || maintain.screws]
 -    pages: [
 -        { name: "Account", title: qsTr("Account") },
-+    dots: (NetworkManager.isLanOnly ? [] : [false]).concat([updater.hasNewVersion || updater.consistency, false, maintain.carbon || maintain.screws, false])
++    dots: (NetworkManager.isLanOnly ? [] : [false]).concat([screenSaver.newX1pOtaAvailable || updater.hasNewVersion || updater.consistency, false, maintain.carbon || maintain.screws, false])
 +    pages: (NetworkManager.isLanOnly ? [] : [ { name: "Account", title: qsTr("Account") } ]).concat([
          { name: "Device", title: qsTr("General") },
 +        //{ name: "X1PLogs", title: qsTr("Logs") },

--- a/bbl_screen-patch/patches/printerui/qml/settings/DevicePage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/settings/DevicePage.qml.patch
@@ -62,7 +62,7 @@
 -        DeviceInfoItem { title: qsTr("Firmware Version"); value: build.version
 -            dot: DeviceManager.updater.hasNewVersion || DeviceManager.updater.consistency
 +        DeviceInfoItem { title: qsTr("Firmware Version"); value: screenSaver.fwVersion
-+            dot: screenSaver.fwIsBusted
++            dot: screenSaver.fwIsBusted || screenSaver.newX1pOtaAvailable
              property var onClicked: triggerVersion
          }
          DeviceInfoItem { title: qsTr("Video"); value: models[number]

--- a/bbl_screen-patch/patches/printerui/qml/settings/SettingListener.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/settings/SettingListener.qml.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/qml/settings/SettingListener.qml
 +++ printer_ui/printerui/qml/settings/SettingListener.qml
-@@ -1,12 +1,70 @@
+@@ -1,12 +1,80 @@
  import QtQuick 2.12
  import UIBase 1.0
  import Printer 1.0
@@ -67,11 +67,21 @@
 +            cfwVersions = otamodules;
 +        }
 +    }
++    
++    property var newX1pOtaAvailable: X1Plus.OTA.status()['ota_available']
++    property var newX1pOtaDidKvetch: false
++    property var newX1pOtaShouldKvetch: newX1pOtaAvailable && !newX1pOtaDidKvetch
++    onNewX1pOtaShouldKvetch: {
++        if (!updater.hasPendingNotify)
++            return
++        if (printIdle)
++            popupUpdate();
++    }
 +
      /* Updater */
  
      id: settingListener
-@@ -18,22 +76,57 @@
+@@ -18,22 +86,77 @@
  
      property var updatePage
      property bool versionNotify
@@ -99,9 +109,29 @@
  
      function popupUpdate() {
 -        if (!printIdle || !updater.hasPendingNotify || versionNotify)
-+        if (!printIdle || (!updater.hasPendingNotify && !fwShouldKvetch) || versionNotify)
++        if (!printIdle || (!updater.hasPendingNotify && !fwShouldKvetch && !newX1pOtaShouldKvetch) || versionNotify)
              return
          updater.clearPendingNotify()
++
++        if (newX1pOtaShouldKvetch) {
++            newX1pOtaDidKvetch = true;
++            
++            versionNotify = true;
++            dialogStack.popupDialog(
++                "TextConfirm", {
++                    name: "X1Plus OTA notify",
++                    type: TextConfirm.YES_NO,
++                    text: qsTr("A new version of X1Plus is available!<br><br>Would you like to go to the update page?"),
++                    callback: function(index) {
++                        if (index === TextConfirm.CONFIRM) {
++                            screen.jumpTo("Settings/Device")
++                            pageStack.push("VersionPage.qml")
++                        }
++                        versionNotify = false;
++                    }
++                });
++            return;
++        }
 +        
 +        /* CFW should pop up the gentle warning. */
 +        if (fwShouldKvetch && !(updater.consistency || updater.forceUpgrade)) {
@@ -135,7 +165,7 @@
          var msg = updater.consistency
                  ? qsTr("The firmware version is abnormal. Repairing and updating are required, or printing cannot be started. Do you want to update now? You can also update later from \"Settings > General > Version\".")
                  : updater.forceUpgrade
-@@ -53,12 +146,8 @@
+@@ -53,12 +176,8 @@
                          // finished: Qt.binding(function() { return settingListener.printIdle }),
                          callback: function(index) {
                              if (index === TextConfirm.CONFIRM) {
@@ -150,7 +180,7 @@
                              }
                              versionNotify = false
                          }
-@@ -98,6 +187,7 @@
+@@ -98,6 +217,7 @@
      property var power: DeviceManager.power
      property bool sleep: power.hasSleep
      property bool aboutToSleep: power.aboutToSleep
@@ -158,7 +188,7 @@
  
      anchors.fill: parent
      color: sleep ? (blackColor ? Colors.gray_800 : "#EFEFEF") : "#80000000"
-@@ -165,7 +255,7 @@
+@@ -165,7 +285,7 @@
              blackColor = !blackColor
          }
      }
@@ -167,7 +197,7 @@
      Connections {
          target: DeviceManager
          ignoreUnknownSignals: false
-@@ -219,14 +309,14 @@
+@@ -219,14 +339,14 @@
              }
          }
      }

--- a/bbl_screen-patch/patches/printerui/qml/settings/VersionPage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/VersionPage.qml
@@ -114,7 +114,8 @@ Item {
             property var mappedData: (modelData.bambu === undefined ?
                                         {"sw_ver": cfwVersion.version, "sn": "", "hw_ver": "" } :
                                         modules.find(el => modelData.bambu == el.name))
-            property var needsUpdate: (!cfwVersion.invalid && mappedData.sn != "N/A" && mappedData.sw_ver.split("/")[0] != cfwVersion.version)
+            property var needsUpdate: (!cfwVersion.invalid && mappedData.sn != "N/A" && mappedData.sw_ver.split("/")[0] != cfwVersion.version) ||
+                                      (modelData.cfw == 'cfw' && X1Plus.OTA.status()['ota_available'])
             width: ListView.view.width
             height: 81
             color: modelData.onClicked === undefined ? "transparent" : backColor.color
@@ -198,7 +199,11 @@ Item {
             TapHandler {
                 onTapped: {
                     console.log(modelData.bambu);
-                    dialogStack.popupDialog('../settings/VersionDialog', { modelData: modelData, mappedData: mappedData, cfwVersion: cfwVersion });
+                    if (modelData.cfw == 'cfw') {
+                        dialogStack.popupDialog('../settings/X1PlusOTADialog', {});
+                    } else {
+                        dialogStack.popupDialog('../settings/VersionDialog', { modelData: modelData, mappedData: mappedData, cfwVersion: cfwVersion });
+                    }
                 }
             }
 

--- a/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
@@ -1,0 +1,255 @@
+import QtQuick 2.0
+import QtQuick.Layouts 1.12
+import UIBase 1.0
+import Printer 1.0
+import "qrc:/uibase/qml/widgets"
+import "../dialog"
+
+import "../X1Plus.js" as X1Plus
+
+Item {
+    property alias name: textConfirm.objectName
+    property var currentVersion: screenSaver.cfwVersions['cfw']['version']
+    property var ota: X1Plus.OTA.status()
+    property var otaEnabled: !!X1Plus.Settings.get("ota.enabled", false)
+    property var downloadBaseFirmware: true /* wire up to switch */
+    property var otaBusy: ota.status != 'IDLE' && ota.status != 'DISABLED'
+    property var progressString: `${(ota.download.bytes / 1048576).toFixed(2)} MB / ${(ota.download.bytes_total / 1048576).toFixed(2)} MB`
+
+    property var buttons: SimpleItemModel {
+        DialogButtonItem {
+            name: "download"; title: ota.ota_is_downloaded ? qsTr("Download base firmware") : qsTr("Download update")
+            isDefault: defaultButton == 0
+            keepDialog: true
+            onClicked: {
+                X1Plus.OTA.download(downloadBaseFirmware);
+            }
+            visible: otaEnabled && !otaBusy && ota.ota_available && (!ota.ota_is_downloaded || (downloadBaseFirmware && !ota.ota_base_is_downloaded))
+        }
+        DialogButtonItem {
+            name: "install"; title: qsTr("Install update")
+            isDefault: defaultButton == 1
+            keepDialog: true
+            onClicked: {
+                var rv = X1Plus.OTA.update();
+                if (rv.status != 'failed') {
+                    otaBusy = true;
+                }
+            }
+            visible: otaEnabled && !otaBusy && ota.ota_available && ota.ota_is_downloaded
+        }
+        DialogButtonItem {
+            name: "no"; title: qsTr("Return")
+            isDefault: defaultButton == 2
+            onClicked: { ; }
+            visible: !otaBusy
+        }
+    }
+    property bool finished: false
+
+    id: textConfirm
+    width: 960
+    height: layout.height
+    
+    RowLayout {
+        id: layout
+        width: 960
+        spacing: 0
+        
+        Image {
+            id: moduleIcon
+            Layout.preferredWidth: 128
+            Layout.preferredHeight: 128
+            Layout.rightMargin: 24
+            Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+            fillMode: Image.PreserveAspectFit
+            source: "../../icon/components/cfw.png"
+        }
+        
+        GridLayout {
+            rowSpacing: 6
+            columnSpacing: 12
+            columns: 2
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+            Layout.maximumWidth: 1000
+            
+            Text {
+                Layout.columnSpan: 2
+                Layout.fillWidth: true
+                Layout.bottomMargin: 18
+                font: Fonts.body_36
+                color: Colors.gray_100
+                wrapMode: Text.Wrap
+                text: "X1Plus updates"
+            }
+
+            
+            Text {
+                Layout.fillWidth: true
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                Layout.columnSpan: 2
+                Layout.bottomMargin: 16
+                text: qsTr("<b>Current X1Plus version</b>: %1").arg(currentVersion)
+            }
+            
+            Text {
+                Layout.fillWidth: true
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                text: otaEnabled ? qsTr("Checking for X1Plus updates is enabled.") : qsTr("Checking for X1Plus updates is disabled.")
+                Layout.columnSpan: otaBusy ? 2 : 1
+            }
+            
+            ZSwitchButton {
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                visible: !otaBusy
+                dynamicChecked: otaEnabled
+                onToggled: {
+                    X1Plus.Settings.put("ota.enabled", checked)
+                }
+            }
+
+            ZLineSplitter {
+                Layout.fillWidth: true
+                Layout.columnSpan: 2
+                Layout.topMargin: 20
+                Layout.bottomMargin: 10
+                alignment: Qt.AlignTop
+                padding: 24
+                color: Colors.gray_300
+                visible: otaEnabled
+            }
+            
+            /*** Last update check ***/
+            
+            Text {
+                text: qsTr("<i>Checking for updates...</i>")
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                visible: otaEnabled && ota.status == 'CHECKING_OTA'
+            }
+            
+            Text {
+                text: qsTr("<b>Last checked for updates</b>: %1").arg(new Date(ota.last_checked * 1000).toLocaleString(undefined, {month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit'}))
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                visible: otaEnabled && ota.status != 'CHECKING_OTA'
+            }
+            
+            ZButton {
+                id: refreshBtn
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                width: 46
+                height: width
+                radius: width / 2
+                anchors.top: accessCodeText.top
+                anchors.horizontalCenter: rtspServerBtn.horizontalCenter
+                type: ZButtonAppearance.Secondary
+                iconPosition: ZButtonAppearance.Center
+                paddingX: 0
+                iconSize: 46
+                textColor: StateColors.get("gray_100")
+                icon: "../../icon/refresh.svg"
+                visible: otaEnabled
+                onClicked: {
+                    X1Plus.OTA.checkNow()
+                }
+                
+                RotationAnimation {
+                    id: rotationId
+                    target: refreshBtn.iconItem
+                    property: "rotation"
+                    loops: Animation.Infinite
+                    alwaysRunToEnd: true
+                    duration: 1000
+                    from: 0
+                    to: 360
+                    running: ota.status == 'CHECKING_OTA'
+                }
+            }
+            
+            Text {
+                text: qsTr("<i>Most recent check for updates failed.  Check your network connection.</i>")
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                visible: otaEnabled && ota.err_on_last_check
+                Layout.columnSpan: 2
+            }
+            
+            /*** New OTA available ***/
+            
+            Text {
+                text: qsTr("You are running the newest version of X1Plus.")
+                font: Fonts.body_26
+                color: Colors.gray_200
+                Layout.topMargin: 10
+                wrapMode: Text.Wrap
+                visible: otaEnabled && !ota.ota_available
+                Layout.columnSpan: 2
+            }
+            
+            Text {
+                text: qsTr("<b>New X1Plus version %1</b> is available!").arg((ota.ota_info || {}).cfwVersion)
+                font: Fonts.body_26
+                color: Colors.gray_200
+                Layout.topMargin: 10
+                wrapMode: Text.Wrap
+                visible: otaEnabled && ota.ota_available
+                Layout.columnSpan: 2
+            }
+            
+            
+            Text {
+                text: ota.status == 'DOWNLOADING_X1P' ? qsTr("X1Plus update download in progress (%1).").arg(progressString) :
+                      ota.ota_is_downloaded ?
+                        qsTr("X1Plus update %1download complete%2.").arg('<b><font color="#20ce62">').arg('</font></b>') :
+                        qsTr("X1Plus update has not been downloaded.")
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                Layout.columnSpan: 2
+                visible: otaEnabled && ota.ota_available
+            }
+
+            Text {
+                text: ota.status == 'DOWNLOADING_BASE' ? qsTr("Base firmware download in progress (%1).").arg(progressString) :
+                      ota.ota_base_is_downloaded ?
+                          qsTr("Base firmware %1download complete%2.").arg('<b><font color="#20ce62">').arg('</font></b>') :
+                        downloadBaseFirmware ? qsTr("Base firmware has not been downloaded, but downloading it from Bambu Lab servers is enabled.") :
+                                               qsTr("Base firmware has not been downloaded, and downloading it is disabled.")
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                Layout.columnSpan: (ota.ota_base_is_downloaded || ota.status == 'DOWNLOADING_BASE') ? 2 : 1
+                visible: otaEnabled && ota.ota_available
+                Layout.fillWidth: true
+            }
+
+            ZSwitchButton {
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                dynamicChecked: downloadBaseFirmware
+                onToggled: {
+                    downloadBaseFirmware = checked
+                }
+                visible: otaEnabled && ota.ota_available && !(ota.ota_base_is_downloaded || ota.status == 'DOWNLOADING_BASE')
+            }
+            
+            Text {
+                text: qsTr("<i>Last download failed: %1</i>").arg(ota.download.last_error)
+                font: Fonts.body_26
+                color: Colors.gray_200
+                wrapMode: Text.Wrap
+                Layout.columnSpan: 2
+                visible: otaEnabled && ota.ota_available && ota.download.last_error
+                Layout.fillWidth: true
+            }
+        }
+    }
+}

--- a/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
@@ -148,8 +148,6 @@ Item {
                 width: 46
                 height: width
                 radius: width / 2
-                anchors.top: accessCodeText.top
-                anchors.horizontalCenter: rtspServerBtn.horizontalCenter
                 type: ZButtonAppearance.Secondary
                 iconPosition: ZButtonAppearance.Center
                 paddingX: 0

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
@@ -76,6 +76,8 @@ function proxyFunction(busName, objName, interface, method) {
         _proxies[busName][objName] = _DBusListener.createProxy(busName, objName);
     }
     return (j) => {
+        if (j === undefined)
+            j = null;
         var s = _proxies[busName][objName].callMethod(interface, method, JSON.stringify(j));
         return JSON.parse(s);
     };

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DBus.js
@@ -79,6 +79,11 @@ function proxyFunction(busName, objName, interface, method) {
         if (j === undefined)
             j = null;
         var s = _proxies[busName][objName].callMethod(interface, method, JSON.stringify(j));
-        return JSON.parse(s);
+        try {
+            return JSON.parse(s);
+        } catch (e) {
+            console.log(`DBus method invocation (${objName} ${interface}.${method}) failed: ${s}`);
+            return null;
+        }
     };
 }

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/OTA.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/OTA.js
@@ -35,7 +35,7 @@ function download(base_firmware = false) {
 }
 
 function update() {
-    _Update({});
+    return _Update({});
 }
 
 function awaken() {
@@ -43,7 +43,7 @@ function awaken() {
     _setStatus(curStatus);
 
     X1Plus.DBus.onSignal("x1plus.ota", "StatusChanged", (arg) => {
-        setStatus(arg);
+        _setStatus(arg);
     });
     
     _CheckNow = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/ota", "x1plus.ota", "CheckNow");

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/OTA.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/OTA.js
@@ -1,0 +1,53 @@
+.pragma library
+
+/* QML interface for x1plusd OTA engine
+ *
+ * Copyright (c) 2024 Joshua Wise, and the X1Plus authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var X1Plus = null;
+
+var status = null;
+var onStatus = null;
+
+var _CheckNow = null;
+var _Download = null;
+var _Update = null;
+
+function checkNow() {
+    _CheckNow({});
+}
+
+function download(base_firmware = false) {
+    _Download({'base_firmware': base_firmware});
+}
+
+function update() {
+    _Update({});
+}
+
+function awaken() {
+    const curStatus = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/ota", "x1plus.ota", "GetStatus")({});
+    const [_status, _onStatus, setStatus] = X1Plus.Binding.makeBinding(curStatus);
+    status = _status;
+    onStatus = _onStatus;
+    X1Plus.DBus.onSignal("x1plus.ota", "StatusChanged", (arg) => {
+        setStatus(arg);
+    });
+    
+    _CheckNow = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/ota", "x1plus.ota", "CheckNow");
+    _Download = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/ota", "x1plus.ota", "Download");
+    _Update   = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/ota", "x1plus.ota", "Update"  );
+}

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/OTA.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/OTA.js
@@ -1,4 +1,5 @@
 .pragma library
+.import "Binding.js" as Binding
 
 /* QML interface for x1plusd OTA engine
  *
@@ -19,8 +20,7 @@
 
 var X1Plus = null;
 
-var status = null;
-var onStatus = null;
+var [status, onStatus, _setStatus] = Binding.makeBinding({});
 
 var _CheckNow = null;
 var _Download = null;
@@ -40,9 +40,8 @@ function update() {
 
 function awaken() {
     const curStatus = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/ota", "x1plus.ota", "GetStatus")({});
-    const [_status, _onStatus, setStatus] = X1Plus.Binding.makeBinding(curStatus);
-    status = _status;
-    onStatus = _onStatus;
+    _setStatus(curStatus);
+
     X1Plus.DBus.onSignal("x1plus.ota", "StatusChanged", (arg) => {
         setStatus(arg);
     });

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
@@ -63,7 +63,7 @@ function awaken() {
             _settingChanged(k, arg[k]);
         }
     });
-    _settings = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/settings", "x1plus.settings", "GetSettings")();
+    _settings = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/settings", "x1plus.settings", "GetSettings")() || {};
     _PutSettings = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/settings", "x1plus.settings", "PutSettings");
     
     for (const k in _settings) {

--- a/bbl_screen-patch/patches/root.qrc.patch
+++ b/bbl_screen-patch/patches/root.qrc.patch
@@ -113,7 +113,7 @@
  <file>printerui/qml/settings/WifiListPage.qml</file>
  <file>printerui/qml/settings/WifiSetupPage.qml</file>
  <file>printerui/qml/wizard/Calibrate1Page.qml</file>
-@@ -235,12 +284,28 @@
+@@ -235,12 +284,29 @@
  <file>printerui/qml/wizard/TermsPage.qml</file>
  <file>printerui/qml/wizard/WelcomePage.qml</file>
  <file>printerui/qml/wizard/WizardPage.qml</file>
@@ -128,6 +128,7 @@
 +<file>printerui/qml/x1plus/GcodeGenerator.js</file>
 +<file>printerui/qml/x1plus/GpioKeys.js</file>
 +<file>printerui/qml/x1plus/MeshCalcs.js</file>
++<file>printerui/qml/x1plus/OTA.js</file>
 +<file>printerui/qml/x1plus/Settings.js</file>
 +<file>printerui/qml/x1plus/ShaperCalibration.js</file>
 +<file>printerui/qml/x1plus/Stats.js</file>
@@ -142,7 +143,7 @@
  <file>printerui/text/error_texts.sv.json</file>
  <file>printerui/text/error_texts.zh-cn.json</file>
  <file>printerui/text/error_texts.zh-tw.json</file>
-@@ -259,6 +324,7 @@
+@@ -259,6 +325,7 @@
  <file>printerui/text/hms_texts.fr.json</file>
  <file>printerui/text/hms_texts.ja.json</file>
  <file>printerui/text/hms_texts.nl.json</file>
@@ -150,7 +151,7 @@
  <file>printerui/text/hms_texts.sv.json</file>
  <file>printerui/text/hms_texts.zh-cn.json</file>
  <file>printerui/text/hms_texts.zh-tw.json</file>
-@@ -295,3 +361,4 @@
+@@ -295,3 +362,4 @@
  <file>printerui/text/terms.zh-cn.txt</file>
  <file>qt-project.org/imports/QtQuick/VirtualKeyboard/Styles/bbl/style.qml</file>
  </qresource></RCC>

--- a/bbl_screen-patch/patches/root.qrc.patch
+++ b/bbl_screen-patch/patches/root.qrc.patch
@@ -98,7 +98,7 @@
  <file>printerui/qml/settings/InputPage.qml</file>
  <file>printerui/qml/settings/MaintenancePage.qml</file>
  <file>printerui/qml/settings/NetParaSetPage.qml</file>
-@@ -217,9 +262,13 @@
+@@ -217,11 +262,16 @@
  <file>printerui/qml/settings/RegionItem.qml</file>
  <file>printerui/qml/settings/ReleaseNotePage.qml</file>
  <file>printerui/qml/settings/SensorPage.qml</file>
@@ -112,8 +112,11 @@
 +<file>printerui/qml/settings/VersionPage.qml</file> 
  <file>printerui/qml/settings/WifiListPage.qml</file>
  <file>printerui/qml/settings/WifiSetupPage.qml</file>
++<file>printerui/qml/settings/X1PlusOTADialog.qml</file>
  <file>printerui/qml/wizard/Calibrate1Page.qml</file>
-@@ -235,12 +284,29 @@
+ <file>printerui/qml/wizard/CalibratePage.qml</file>
+ <file>printerui/qml/wizard/CalibratingPage.qml</file>
+@@ -235,12 +285,29 @@
  <file>printerui/qml/wizard/TermsPage.qml</file>
  <file>printerui/qml/wizard/WelcomePage.qml</file>
  <file>printerui/qml/wizard/WizardPage.qml</file>
@@ -143,7 +146,7 @@
  <file>printerui/text/error_texts.sv.json</file>
  <file>printerui/text/error_texts.zh-cn.json</file>
  <file>printerui/text/error_texts.zh-tw.json</file>
-@@ -259,6 +325,7 @@
+@@ -259,6 +326,7 @@
  <file>printerui/text/hms_texts.fr.json</file>
  <file>printerui/text/hms_texts.ja.json</file>
  <file>printerui/text/hms_texts.nl.json</file>
@@ -151,7 +154,7 @@
  <file>printerui/text/hms_texts.sv.json</file>
  <file>printerui/text/hms_texts.zh-cn.json</file>
  <file>printerui/text/hms_texts.zh-tw.json</file>
-@@ -295,3 +362,4 @@
+@@ -295,3 +363,4 @@
  <file>printerui/text/terms.zh-cn.txt</file>
  <file>qt-project.org/imports/QtQuick/VirtualKeyboard/Styles/bbl/style.qml</file>
  </qresource></RCC>

--- a/images/cfw/etc/init.d/S72x1plusd
+++ b/images/cfw/etc/init.d/S72x1plusd
@@ -5,7 +5,21 @@
 start() {
 	printf "Starting x1plusd: "
 	start-stop-daemon -S -m -b -p /var/run/x1plusd.pid --exec /opt/python/bin/python3 -- -m x1plus.services.x1plusd
-    [ $? = 0 ] && echo "OK" || echo "FAIL"
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+	printf "Waiting for x1plusd to be active on DBus... "
+	i=0
+	for i in `seq 10 -1 0`; do
+		dbus-send --system --print-reply --dest=x1plus.x1plusd /x1plus/ota x1plus.ota.GetStatus string:'{}' >/dev/null 2>/dev/null
+		if [ $? = 0 ]; then
+			echo "OK"
+			break
+		fi
+		printf "$i... "
+		sleep 1
+	done
+	if [ $i = -1 ]; then
+		echo "timed out"
+	fi
 }
 stop() {
 	printf "Stopping x1plusd: "

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
@@ -320,6 +320,8 @@ class OTAService(X1PlusDBusService):
             if not ota_enabled:
                 logger.debug(f"OTA engine is disabled, so we are definitely doing nothing")
                 self.task_status = OTAService.STATUS_DISABLED
+            else:
+                self.task_status = OTAService.STATUS_IDLE
             
             await self._maybe_publish_status_object()
             


### PR DESCRIPTION
Adds a dialog that can drive x1plusd.ota, as well as a popup for when a new version of X1Plus is detected.

![image](https://github.com/X1Plus/X1Plus/assets/87427/7c2d2b2f-52f5-4ee3-9c83-62560f8e56fe)

![image](https://github.com/X1Plus/X1Plus/assets/87427/29ba82ee-a473-4ac8-a685-5ee43f47dcc0)

![image](https://github.com/X1Plus/X1Plus/assets/87427/ba684b21-68a5-4d27-a5a2-8cac2aac0e3f)

![image](https://github.com/X1Plus/X1Plus/assets/87427/19d5bc71-4612-4fd0-a2c0-2c7a9ca8f7f0)

![image](https://github.com/X1Plus/X1Plus/assets/87427/29c86bd3-a6e8-40ef-8f57-bf4c91707661)

![image](https://github.com/X1Plus/X1Plus/assets/87427/f6539656-432d-42fb-99e2-0a917a3f5efa)
