### PR TITLE
Changes to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,20 +76,26 @@ $ docker exec -v `pwd`:/work x1plusmake sh -c 'ls /work | grep .x1p'
 $ <somefilename>.x1p
 ```
 
-Copy that out of the Docker container 
+Copy that out of the Docker container. 
 
 ```
-$ docker cp x1plusmake:/work/<somefilename>.x1p .
+$ docker cp x1plusmake:/work/<somefilename>.x1p
 ```
 
-And `scp` it to the printer. NEVER remove an SD card from a live X1Plus system, 
-you goofball!
+And `scp` it to the printer (never remove an SD card from a live X1Plus system, 
+you goofball).
 
 ```
-scp <somefilename>.x1p root@<printer’s IP>/sdcard
+scp <somefilename>.x1p root@<printer’s IP>:/sdcard
 ```
 
-Reboot your printer, and install it from the menu.
+Reboot your printer, and install X1Plus from the menu.
+
+Finally, don't forget to stop your Docker container!
+
+```
+docker stop x1plusmake
+```
 
 If you're going to make changes to any of the UI files, you should really
 read the rest of this document...  otherwise you might be in for a nasty

--- a/README.md
+++ b/README.md
@@ -29,13 +29,38 @@ container.  If you're adventurous, you can probably build X1Plus on any old
 Linux machine (I do), but if you do that and it breaks, we really don't want
 to hear about it, so you really should just build it in Docker.  You'll need
 the filesystem decryption key from a live printer (running either X1Plus or
-the Official Rootable Firmware) in order to build X1Plus; try something
-like:
+the Official Rootable Firmware) in order to build X1Plus
+
+First, copy the getkey bin over to the printer:
+
+```
+scp scp scripts/getkey root@<printer’s IP>:/tmp
+```
+
+Now retrieve the key:
+
+```
+ssh root@<printer’s IP> /tmp/getkey >> localconfig.mk
+```
+
+Clone down the X1Plus repo and build the Docker image from the Dockerfile in `scripts/docker`:
 
 ```
 $ git clone ...
 $ cd X1Plus
 $ docker build -t x1plusbuild scripts/docker/
+```
+
+To get the make to work on the Docker container a safe directory must be added to the
+git config. As that will only persist for one run the Docker container must be run in interactive mode. 
+
+```
+$ docker run -it -v `pwd`:/work x1plusbuild 
+```
+
+
+
+```
 $ docker run -u `id -u` -v `pwd`:/work x1plusbuild bash -c 'git config --global --add safe.directory /work'
 $ docker run -u `id -u` -v `pwd`:/work x1plusbuild make scripts
 $ scp scripts/getkey root@bambu:/tmp


### PR DESCRIPTION
I had some trouble making the .x1p file from the Dockerfile with the given instructions, so I made them way more detailed for the next guy like me who shows up and hasn't used Docker in a while.

Note that I left out `` `id -u` `` from all the docker commands. On the Mac that was causing problems, because it gives a different value than `` `id -u` `` does on Linux, and it didn't seem necessary, anyway. I did not test these commands on Linux or Windows, although since it's in a Docker container it _should_ be platform-agnostic.