### PR TITLE
Update HardwarePage.qml tooltip text

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
@@ -542,7 +542,7 @@ Rectangle {
                         font: Fonts.body_22
                         color: Colors.gray_300
                         text: "<b>" + label + "</b>: " + description
-                        wrapMode: Text.WordWra
+                        wrapMode: Text.WordWrap
                     }
                 }
                 Text {

--- a/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
@@ -495,20 +495,71 @@ Rectangle {
 
         contentComponent: Rectangle {
             radius: 15
+            width: parent.width
+            height: parent.height
             color: Colors.gray_600
-            Text {
-                width: 670
-                wrapMode: Text.WordWrap
-                anchors.centerIn: parent
-                font: Fonts.body_24
-                color: Colors.gray_200
-                text: qsTr("<b>You can change the behavior of the hardware buttons on the top of the printer.</b>  A short press is less than 0.85 seconds, and a long press is anything longer than that.<br><br>" +
-                           "<b>Reboot</b>: gracefully restarts Linux with 'reboot' command.<br>" +
-                           "<b>Set temp</b>: sets nozzle or bed target temperature.<br>" + 
-                           "<b>Pause print</b>: pauses current print job.  (Original behavior for red button.)<br>" + 
-                           "<b>Abort print</b>: cancels current print job.<br>" +
-                           "<b>Sleep/wake</b>: toggles display screen saver.  (Original behavior for black button.)<br>" +
-                           "<b>Run macro</b>: executes G-code or Python macro.")
+            
+            Column {
+                width: parent.width
+                height: parent.height
+                anchors.top: parent.top
+                anchors.topMargin: 45
+                anchors.left: parent.left
+                anchors.leftMargin: 50
+                anchors.right: parent.right
+                anchors.rightMargin: 50
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: 50
+                spacing: 20
+
+                Text {
+                    font: Fonts.body_30
+                    color: Colors.gray_200
+                    wrapMode: Text.WordWrap
+                    text: qsTr("Tooltip: Re-mapping the hardware buttons") 
+                }
+                Rectangle {
+                    width: parent.width - 100
+                    height: 1
+                    color: Colors.gray_200
+                }
+                Text {
+                    font: Fonts.body_24
+                    color: Colors.gray_200
+                    text: qsTr("Button Actions:")
+                }
+                ListView {
+                    width: parent.width - 40
+                    height: 160
+                    model: ListModel { //Note for when we refactor Gpiokeys - these strings should be stored in Gpiokeys.js
+                        ListElement { label: "Sleep/wake"; description: qsTr("Toggles LCD screen (and lock screen if configured)") }
+                        ListElement { label: "Reboot"; description: qsTr("Restarts Linux with a shell command") }
+                        ListElement { label: "Pause print"; description: qsTr("Pauses current print job.") } 
+                        ListElement { label: "Abort print"; description: qsTr("Aborts current print job.") }
+                        ListElement { label: "Ignore"; description: qsTr("No action") }
+                    }
+                    delegate: Text {
+                        font: Fonts.body_22
+                        color: Colors.gray_300
+                        text: "<b>" + label + "</b>: " + description
+                        wrapMode: Text.WordWra
+                    }
+                }
+                Text {
+                    font: Fonts.body_24
+                    color: Colors.gray_200
+                    text: qsTr("Button Press Gestures:")
+                }
+                Text {
+                    font: Fonts.body_22
+                    color: Colors.gray_300
+                    text: qsTr("Short press: < 0.85 seconds")
+                }
+                Text {
+                    font: Fonts.body_22
+                    color: Colors.gray_300
+                    text: qsTr("Long press: >= 0.85 seconds")
+                }
             }
         }
     }

--- a/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
@@ -532,11 +532,11 @@ Rectangle {
                     width: parent.width - 40
                     height: 160
                     model: ListModel { //Note for when we refactor Gpiokeys - these strings should be stored in Gpiokeys.js
-                        ListElement { label: "Sleep/wake"; description: qsTr("Toggles LCD screen (and lock screen if configured)") }
-                        ListElement { label: "Reboot"; description: qsTr("Restarts Linux with a shell command") }
-                        ListElement { label: "Pause print"; description: qsTr("Pauses current print job.") } 
-                        ListElement { label: "Abort print"; description: qsTr("Aborts current print job.") }
-                        ListElement { label: "Ignore"; description: qsTr("No action") }
+                        ListElement { label: qsTr("Sleep/wake"); description: qsTr("Toggles LCD screen (and lock screen if configured)") }
+                        ListElement { label: qsTr("Reboot"); description: qsTr("Restarts Linux with a shell command") }
+                        ListElement { label: qsTr("Pause print"); description: qsTr("Pauses current print job.") } 
+                        ListElement { label: qsTr("Abort print"); description: qsTr("Aborts current print job.") }
+                        ListElement { label: qsTr("Ignore"); description: qsTr("No action") }
                     }
                     delegate: Text {
                         font: Fonts.body_22


### PR DESCRIPTION
- Strings for button action description in tooltip text in HardwarePage.qml have been moved to a ListModel.

- Updated the text for this tooltip (outdated since v1.1) - removed old button actions that no longer exist, and defined the new one ("Ignore")

- Moves html tags outside of translation tags 

Screenshot:
<img width="350" alt="image" src="https://github.com/X1Plus/X1Plus/assets/149451641/4e4388f4-309c-45ec-b409-18a03424b93b">
