### PR TITLE
Make OTA Engine Enabled By Default

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/settings.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/settings.py
@@ -36,7 +36,7 @@ class SettingsService(X1PlusDBusService):
         "boot.dump_emmc": False,
         "boot.sdcard_syslog": False,
         "boot.perf_log": False,
-        "ota.enabled": False,
+        "ota.enabled": True,
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
The OTA engine was disabled by default, so I made it enabled. I don't belive we need any UI changes, and I changed the wrong file originally, fixed it now.