### PR TITLE
ota: default to enabled

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
@@ -11,7 +11,7 @@ Item {
     property alias name: textConfirm.objectName
     property var currentVersion: screenSaver.cfwVersions['cfw']['version']
     property var ota: X1Plus.OTA.status()
-    property var otaEnabled: !!X1Plus.Settings.get("ota.enabled", false)
+    property var otaEnabled: !!X1Plus.Settings.get("ota.enabled", true)
     property var downloadBaseFirmware: true /* wire up to switch */
     property var otaBusy: ota.status != 'IDLE' && ota.status != 'DISABLED'
     property var progressString: `${(ota.download.bytes / 1048576).toFixed(2)} MB / ${(ota.download.bytes_total / 1048576).toFixed(2)} MB`

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
@@ -69,7 +69,7 @@ class OTAService(X1PlusDBusService):
         )
 
     def ota_enabled(self):
-        return bool(self.x1psettings.get("ota.enabled", False))
+        return bool(self.x1psettings.get("ota.enabled", True))
 
     async def task(self):
         # On startup run an update check to populate info

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/settings.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/settings.py
@@ -31,13 +31,7 @@ class SettingsService(X1PlusDBusService):
     DBus invocation tool (currently, x1plus-test-settings).
     """
 
-    DEFAULT_X1PLUS_SETTINGS = {
-        "boot.quick_boot": False,
-        "boot.dump_emmc": False,
-        "boot.sdcard_syslog": False,
-        "boot.perf_log": False,
-        "ota.enabled": False,
-    }
+    DEFAULT_X1PLUS_SETTINGS = { }
 
     def __init__(self, **kwargs):
         if x1plus.utils.is_emulating():


### PR DESCRIPTION
For some reason, originally we thought that the OTA engine should default to disabled.  This is clearly wrong.  It should default to enabled.  While we're in there, remove the other confusing defaults that are not useful and just add clutter and confusion.