### PR TITLE
Only allow installation on modern X1 base firmware.

### DIFF
--- a/installer/install.py
+++ b/installer/install.py
@@ -47,7 +47,7 @@ basefw_mtime = INFO["base"]["mtime"]
 cfw_version = INFO["cfwVersion"]
 cfw_squashfs = f"{cfw_version}.squashfs"
 demand_free_space = fs_size + 1 * 1024 * 1024 * 1024
-# latest_safe_bblap = "00.00.28.55" # 1.07.02.00
+oldest_safe_bblap = "00.00.28.55" # 1.07.02.00 - anything older is not guaranteed to have a safe RPMB migration
 latest_safe_bblap = "00.00.30.73" # Firmware R - "1.06.06.58" aka 1.07.02.00+R
 
 dds_rx_queue = dds.subscribe("device/request/upgrade")
@@ -260,6 +260,13 @@ if not os.path.isfile(backup_path):
 
 # validate that we're on a machine that has a supported device tree
 report_progress("Checking system compatibility")
+
+with open("/etc/bblap/Version", "r") as apvf:
+    apv = apvf.read().strip()
+    if apv > latest_safe_bblap:
+        report_failure(f"Installed firmware version {apv} is too new for this version of X1Plus.")
+    if apv < oldest_safe_bblap:
+        report_failure(f"Installed firmware version {apv} is too old for this version of X1Plus.  You must upgrade to the Official Rootable Firmware to install this version of X1Plus.")
 
 if not os.path.isfile(f"{installer_path}/kernel/{device_tree_compute_key()}.dts"):
     report_failure("This custom firmware image does not support this printer's hardware version.")


### PR DESCRIPTION
Over the last few weeks, there have been a handful of incidents that took up a decent amount of X1Plus support bandwidth associated with truly ancient base firmware making trouble for the X1Plus install process or runtime (in one case, a user ran across the known Bambu Lab RPMB migration bug associated with older firmware -- or had the wrong trustlets running -- and, in the other case, the init sequence in an ancient version of X1 firmware was different enough to break the WiFi setup process in the X1Plus installer).  We solve this by enforcing at install time that X1Plus must be installed on top of either 01.07.02.00 or the Official Rootable Firmware (which is 01.07.02.00 "plus a little extra stuff").  As an added bonus, this now will have an error at the beginning, rather than the end, of installation, if the on-eMMC firmware does not match a known version.  This will impact very few users (only users who previously installed using the exploit, on an ancient version); users who are affected will be given a clear failure message with a path forward.  (Technically savvy users who do not wish to upgrade to the Official Rootable Firmware may compile their own versions of X1Plus that do not have this warning; this configuration would be clearly unsupported.)