### PR TITLE
WiFi status indicator for kexec_ui

### DIFF
--- a/bbl_screen-patch/kexec_ui/printerui/qml/Screen.qml
+++ b/bbl_screen-patch/kexec_ui/printerui/qml/Screen.qml
@@ -33,7 +33,30 @@ Rectangle {
     height: 720
     color: Colors.gray_500
     
+    WifiStatus {
+        id: _wifiStatus
+    }  
+    
+    Text {
+        id: wifiLevelTxt
+        z: 1
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: 25
+        anchors.rightMargin: 60
+        width: 100
+        height: 50
+        color: "white"
+        font: Fonts.body_28
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        Binding on text {
+            value: _wifiStatus.formattedOutput
+        }
+    }
+    
     Component.onCompleted: {
+        _wifiStatus.run("wifi_signal"); //check if LAN mode is enabled
         if (X1PlusNative.getenv("KEXEC_LAUNCH_INSTALLER") != "")
             dialogStack.push("SelectX1pPage.qml", { noBackButton: true } );
         else

--- a/bbl_screen-patch/kexec_ui/printerui/qml/WifiStatus.qml
+++ b/bbl_screen-patch/kexec_ui/printerui/qml/WifiStatus.qml
@@ -1,0 +1,76 @@
+import X1PlusProcess 1.0
+import QtQuick 2.12
+import X1PlusNative 1.0
+
+Item {
+    property string lastOutput: "" 
+    property string formattedOutput: ""
+    property bool running: false
+    property var lanMode: false
+    property var workarounds: X1PlusNative.getenv("EMULATION_WORKAROUNDS")
+    signal processStateChanged(bool running)
+    
+    property var shellScript: [
+        {
+            name: "wifi_signal",
+            script:  `
+                while true; do
+                    conn_mode=$(cat ${workarounds}/config/device/conn_mode)
+
+                    if [ "$conn_mode" == "lan" ]; then
+                        echo "lan"
+                        
+                    elif [ "$conn_mode" == "cloud" ]; then
+                        signal_level=$(awk 'NR==3 {print $4}' "${workarounds}/proc/net/wireless" | sed -E 's/[^0-9.-]+//g; s/\.$//')
+                        echo "$signal_level"
+                        sleep 3
+                    fi
+                    sleep 5
+                done
+
+            `
+        }
+    ]    
+
+    X1PlusProcess {
+        id: qproc
+        onReadyReadStandardOutput: {
+            lastOutput = qproc.readLine().toString().trim();
+            if (lastOutput == "lan"){
+                lanMode = true;
+                formattedOutput = "<font color='#ffb3ba'>LAN mode</font>";
+                return
+            } else {
+                lanMode = false;
+                if (lastOutput == "" || isNaN(Number(lastOutput))){
+                    formattedOutput = `<font color='#fe6f47'>WiFi: n/a</font>`;
+                } else {
+                    formattedOutput = `<font color='#6fcc9f'>WiFi: ${lastOutput} dBm</font>`;
+                }     
+            }          
+        }
+        onErrorOccurred: {
+            updateState(false);
+        }
+        onStarted:{
+            updateState(true);
+        }
+        onFinished:{
+            updateState(false);
+            
+        }
+    }
+    function updateState(isRunning) {
+        running = isRunning;
+        processStateChanged(running);
+    }
+
+    function run(name) {
+        if (running) qproc.terminate();
+        let w = shellScript.find(script => script.name === name);
+        if (w) {
+            qproc.start("/bin/bash", ["-c", w.script]);
+            running = true;
+        }
+    }
+}

--- a/bbl_screen-patch/kexec_ui/root.qrc
+++ b/bbl_screen-patch/kexec_ui/root.qrc
@@ -16,6 +16,7 @@
 <file>printerui/qml/dialog/Success.qml</file>
 <file>printerui/qml/dialog/TextConfirm.qml</file>
 <file>printerui/qml/dialog/DialogButtonItem.qml</file>
+<file>printerui/qml/WifiStatus.qml</file>
 <file>printerui/qml/Dialog.qml</file>
 <file>printerui/qml/Choise.qml</file>
 <file>printerui/qml/Screen.qml</file>


### PR DESCRIPTION
This uses a QProcess and shell script to check `/config/device/conn_mode` and `/proc/net/wireless` to see if the printer is in LAN mode or if it's active and reports a signal strength. The type is initialized in Screen.qml so it appears everywhere in kexec_ui. Updates are handled with bindings.

## WiFi enabled, signal strength is displayed
<img src="https://github.com/X1Plus/X1Plus/assets/149451641/133d245e-d83b-4faa-9ef0-8438cf6100b2" width="50%">

## LAN mode is turned on
<img src="https://github.com/X1Plus/X1Plus/assets/149451641/c908b485-caef-420d-993d-bd6f9f1f56b2" width="50%">


## WiFi is not enabled, and there is no signal strength to report
<img src="https://github.com/X1Plus/X1Plus/assets/149451641/4f79fa67-4fde-4f09-8a90-c4e1bd3547d3"  width="50%">
