### PR TITLE
OTA and updater: do not attempt to download updates in Shield Mode

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/SettingListener.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/settings/SettingListener.qml.patch
@@ -70,7 +70,7 @@
 +    
 +    property var newX1pOtaAvailable: X1Plus.OTA.status()['ota_available']
 +    property var newX1pOtaDidKvetch: false
-+    property var newX1pOtaShouldKvetch: newX1pOtaAvailable && !newX1pOtaDidKvetch
++    property var newX1pOtaShouldKvetch: newX1pOtaAvailable && !newX1pOtaDidKvetch && !DeviceManager.getSetting("cfw_shield", false)
 +    onNewX1pOtaShouldKvetch: {
 +        if (!updater.hasPendingNotify)
 +            return

--- a/bbl_screen-patch/patches/printerui/qml/settings/UpgradeDialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/UpgradeDialog.qml
@@ -15,6 +15,7 @@ Item {
     property var url: ""
     property var md5: ""
     property var fileName: url.substring(url.lastIndexOf("/") + 1)
+    property var isShield: DeviceManager.getSetting("cfw_shield", false)
     property var localPath: `/sdcard/x1plus/firmware/${fileName}`
     property var isDownloaded: false
     property var md5Failed: false
@@ -37,7 +38,7 @@ Item {
             isDefault: defaultButton == 0
             keepDialog: true
             onClicked: { downloadToCache(); }
-            visible: !isDownloaded && !downloadInProgress && !isInstalling
+            visible: !isDownloaded && !downloadInProgress && !isInstalling && !isShield
         }
         DialogButtonItem {
             name: "install"; title: qsTr("Install %1").arg(version)
@@ -234,7 +235,8 @@ Item {
                 color: Colors.gray_200
                 wrapMode: Text.Wrap
                 visible: !isDownloaded && !downloadInProgress && !md5Failed
-                text: qsTr("Version %1 does not exist on the SD card. Download it now?<br><br>This requires an active Internet connection, and will connect to Bambu Lab servers.").arg(version)
+                text: isShield ? qsTr("Version %1 does not exist on the SD card. You must take your printer out of Shield Mode in order to download it, or copy it manually to your SD card.").arg(version)
+                               : qsTr("Version %1 does not exist on the SD card. Download it now?<br><br>This requires an active Internet connection, and will connect to Bambu Lab servers.").arg(version)
             }
 
             Text {
@@ -244,7 +246,8 @@ Item {
                 color: Colors.gray_200
                 wrapMode: Text.Wrap
                 visible: !isDownloaded && !downloadInProgress && md5Failed
-                text: qsTr("Version %1 exists on the SD card, but appears to be corrupt. Redownload it now?<br><br>This requires an active Internet connection, and will connect to Bambu Lab servers.").arg(version)
+                text: isShield ? qsTr("Version %1 exists on the SD card, but appears to be corrupt. You must take your printer out of Shield Mode in order to download it, or copy it manually to your SD card.").arg(version)
+                               : qsTr("Version %1 exists on the SD card, but appears to be corrupt. Redownload it now?<br><br>This requires an active Internet connection, and will connect to Bambu Lab servers.").arg(version)
             }
 
             /* Phase: download. */

--- a/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/X1PlusOTADialog.qml
@@ -10,8 +10,9 @@ import "../X1Plus.js" as X1Plus
 Item {
     property alias name: textConfirm.objectName
     property var currentVersion: screenSaver.cfwVersions['cfw']['version']
+    property var isShield: DeviceManager.getSetting("cfw_shield", false)
     property var ota: X1Plus.OTA.status()
-    property var otaEnabled: !!X1Plus.Settings.get("ota.enabled", true)
+    property var otaEnabled: !!X1Plus.Settings.get("ota.enabled", true) && !isShield
     property var downloadBaseFirmware: true /* wire up to switch */
     property var otaBusy: ota.status != 'IDLE' && ota.status != 'DISABLED'
     property var progressString: `${(ota.download.bytes / 1048576).toFixed(2)} MB / ${(ota.download.bytes_total / 1048576).toFixed(2)} MB`
@@ -100,13 +101,14 @@ Item {
                 font: Fonts.body_26
                 color: Colors.gray_200
                 wrapMode: Text.Wrap
-                text: otaEnabled ? qsTr("Checking for X1Plus updates is enabled.") : qsTr("Checking for X1Plus updates is disabled.")
+                text: isShield ? qsTr("X1Plus cannot check for updates while the printer is in Shield Mode.") :
+                      otaEnabled ? qsTr("Checking for X1Plus updates is enabled.") : qsTr("Checking for X1Plus updates is disabled.")
                 Layout.columnSpan: otaBusy ? 2 : 1
             }
             
             ZSwitchButton {
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                visible: !otaBusy
+                visible: !otaBusy && !isShield
                 dynamicChecked: otaEnabled
                 onToggled: {
                     X1Plus.Settings.put("ota.enabled", checked)


### PR DESCRIPTION
There was, at least, some confusion associated with OTA updates in Shield Mode.  Add some language to make it clearer that both X1Plus OTA and microcontroller firmware update downloads are not supported in Shield Mode.

The `x1plus ota` will still time out attempting to check for updates if the printer is in Shield Mode.  If you are ssh'ed into the printer, you should know what's coming to you.

Tested in emulation.