### PR TITLE
Add support for USB Ethernet adapters on X1 Carbon

### DIFF
--- a/bbl_screen-patch/Makefile
+++ b/bbl_screen-patch/Makefile
@@ -7,7 +7,7 @@ TARGET_CC ?= $(TOOLCHAIN)gcc
 LDFLAGS = -shared -ldl
 CXXFLAGS = -fPIC -std=c++11 -Ivendor -O3 -mcpu=cortex-a7 # yes, -O3 actually helps here with the VNC shenanigans
 CFLAGS = -fPIC -Ivendor -O3 -mcpu=cortex-a7 # yes, -O3 actually helps here with the VNC shenanigans
-MODULES := kexec_ui.so printer_ui printer_ui.so printer_ui.so.xdelta uncurl.so evdev_fix.so base.ts workaround_ifaddrs.so device_gate_shim.so
+MODULES := kexec_ui.so printer_ui printer_ui.so printer_ui.so.xdelta uncurl.so evdev_fix.so base.ts workaround_ifaddrs.so device_gate_shim.so netService_shim.so
 
 .DELETE_ON_ERROR:
 .SUFFIXES:
@@ -64,9 +64,11 @@ base.ts: printer_ui.so kexec_ui.so
 %.so: %.c
 	$(TARGET_CC) -o $@ $< $(CFLAGS) $(LDFLAGS)
 
+%.so: %.cpp
+	$(TARGET_CC) -o $@ $< $(CXXFLAGS) $(LDFLAGS)
+
 device_gate_shim.so: workaround_ifaddrs.c link_is_up.cpp
 	$(TARGET_CC) -o $@ workaround_ifaddrs.c link_is_up.cpp $(CXXFLAGS) $(LDFLAGS)
-
 
 kexec_ui.so: kexec_ui.ui.o interpose.cpp interpose.moc.h
 	$(TARGET_CC) -o $@ $< interpose.cpp workaround_ifaddrs.c $(CXXFLAGS) $(LDFLAGS) -I $(QT5_INCL_PATH)

--- a/bbl_screen-patch/Makefile
+++ b/bbl_screen-patch/Makefile
@@ -7,7 +7,7 @@ TARGET_CC ?= $(TOOLCHAIN)gcc
 LDFLAGS = -shared -ldl
 CXXFLAGS = -fPIC -std=c++11 -Ivendor -O3 -mcpu=cortex-a7 # yes, -O3 actually helps here with the VNC shenanigans
 CFLAGS = -fPIC -Ivendor -O3 -mcpu=cortex-a7 # yes, -O3 actually helps here with the VNC shenanigans
-MODULES := kexec_ui.so printer_ui printer_ui.so printer_ui.so.xdelta uncurl.so evdev_fix.so base.ts workaround_ifaddrs.so
+MODULES := kexec_ui.so printer_ui printer_ui.so printer_ui.so.xdelta uncurl.so evdev_fix.so base.ts workaround_ifaddrs.so device_gate_shim.so
 
 .DELETE_ON_ERROR:
 .SUFFIXES:
@@ -63,6 +63,10 @@ base.ts: printer_ui.so kexec_ui.so
 
 %.so: %.c
 	$(TARGET_CC) -o $@ $< $(CFLAGS) $(LDFLAGS)
+
+device_gate_shim.so: workaround_ifaddrs.c link_is_up.cpp
+	$(TARGET_CC) -o $@ workaround_ifaddrs.c link_is_up.cpp $(CXXFLAGS) $(LDFLAGS)
+
 
 kexec_ui.so: kexec_ui.ui.o interpose.cpp interpose.moc.h
 	$(TARGET_CC) -o $@ $< interpose.cpp workaround_ifaddrs.c $(CXXFLAGS) $(LDFLAGS) -I $(QT5_INCL_PATH)

--- a/bbl_screen-patch/interpose.cpp
+++ b/bbl_screen-patch/interpose.cpp
@@ -75,10 +75,10 @@ void mocdump() {
         }
         printf("%d == %s (%s)\n", tp, tn, mo->className());
         for (int m = mo->methodOffset(); m < mo->methodCount(); m++) {
-            printf("  method: %s\n", mo->method(m).methodSignature().data());
+            printf("  method: %d %s\n", m, mo->method(m).methodSignature().data());
         }
         for (int p = mo->propertyOffset(); p < mo->propertyCount(); p++) {
-            printf("  property: %s %s\n", mo->property(p).typeName(), mo->property(p).name());
+            printf("  property: %d %s %s\n", p, mo->property(p).typeName(), mo->property(p).name());
         }
         for (int e = mo->enumeratorOffset(); e < mo->enumeratorCount(); e++) {
             QMetaEnum me = mo->enumerator(e);

--- a/bbl_screen-patch/link_is_up.cpp
+++ b/bbl_screen-patch/link_is_up.cpp
@@ -1,0 +1,18 @@
+#include <string>
+
+extern int is_wifi_ready();
+extern int is_wried_ready(); /* yes, wried. */
+
+extern int link_is_up(std::string &link) {
+	int rv;
+	if ((rv = is_wried_ready()) != 0) {
+		link = "eth";
+		return rv;
+	}
+	if ((rv = is_wifi_ready()) != 0) {
+		link = "wifi";
+		return rv;
+	}
+	link.clear();
+	return 0;
+}

--- a/bbl_screen-patch/netService_shim.cpp
+++ b/bbl_screen-patch/netService_shim.cpp
@@ -1,0 +1,177 @@
+// ../../gcc-linaro-6.3.1-2017.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -shared -fPIC shim.cpp -ldl -o libnetService_shim.so
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <string>
+#include <stdarg.h>
+#include <link.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <syslog.h>
+
+#if 0
+extern "C" void syslog(int priority, const char *format, ...)
+{
+	va_list va;
+
+	va_start(va, format);
+	vprintf(format, va);
+	printf("\n");
+	va_end(va);
+}
+#endif
+
+void sub_57D50(unsigned int *a1)
+{
+	printf("!!!!!!!!!!!!!!! sub_57D50 !!!!!!!!!!!!!");
+	exit(0);
+}
+
+unsigned int eth_vtbl[] =
+{
+	0x00056A4C,
+	0x00056A64,
+	(unsigned int) sub_57D50,
+	0x00056AD4,
+	0x00056AD8
+};
+
+static int create_interfaces(int thiz)
+{	
+	int v3 = thiz + 0x18C;
+
+	syslog(6, "%s", "create_interfaces");
+
+	unsigned int *wlan_ptr = (unsigned int *)operator new(0x380);
+	wlan_ptr[0] = 0xA1FA8;
+	wlan_ptr[1] = 1;
+	wlan_ptr[2] = 1;
+	
+	{
+	std::string iface = "wlan0";
+	((void (*)(int, std::string &)) 0x6F988)((int)(wlan_ptr + 4), iface);
+	}
+
+	{
+	std::string iface = "wlan0";
+	unsigned int *v4 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+
+	unsigned int *v5 = (unsigned int *)operator new(0x130);
+	v5[0] = 0xA1FC4;
+	v5[1] = 1;
+	v5[2] = 1;
+
+	((void (*)(int)) 0x28F94)((int)(v5 + 4));
+
+	unsigned int *v6 = (unsigned int *)v4[1];
+	v4[0] = (unsigned int) (v5 + 4);
+	v4[1] = (unsigned int) v5;
+
+	if (v6)
+		((void (*)(unsigned int *)) 0x3108C)(v6);
+	}
+
+	{
+	std::string iface = "wlan0";
+	unsigned int v7 = *((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int *v12[2];
+	v12[0] = wlan_ptr + 4;
+	v12[1] = wlan_ptr;
+	
+        __gnu_cxx::__exchange_and_add_dispatch((int *) &wlan_ptr[1], 1);
+
+        ((void (*)(unsigned int, unsigned int **)) 0x2E810)(v7, v12);
+	if (v12[1])
+		((void (*)(unsigned int *)) 0x3108C)(v12[1]);
+	}
+	
+	{
+	std::string iface = "wlan0";
+	unsigned int *v10 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+
+	((void (*)(unsigned int)) 0x287B0)(*v10);
+	}
+
+	(*(void (**)(unsigned int *))(wlan_ptr[4] + 40))(wlan_ptr + 4);
+	((void (*)(unsigned int *)) 0x3108C)(wlan_ptr);
+	
+	syslog(6, "%s", "[NetService::create_interfaces] enable wired network");
+	
+	unsigned int *eth_ptr = (unsigned int *)operator new(0x218);
+	eth_ptr[0] = (unsigned int) eth_vtbl;
+	eth_ptr[1] = 1;
+	eth_ptr[2] = 1;
+	
+	{
+	std::string iface = "eth0";
+	((void (*)(int, std::string &)) 0x875C4)((int)(eth_ptr + 4), iface);
+	}
+
+	{
+	std::string iface = "eth0";
+	unsigned int *v21 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+
+	unsigned int *v14 = (unsigned int *)operator new(0x130);
+	v14[0] = 0xA1FC4;
+	v14[1] = 1;
+	v14[2] = 1;
+	((void (*)(int)) 0x28F94)((int)(v14 + 4));
+	
+	unsigned int *v15 = (unsigned int *)v21[1];
+	v21[0] = (unsigned int) (v14 + 4);
+	v21[1] = (unsigned int) v14;
+	
+	if (v15)
+		((void (*)(unsigned int *)) 0x3108C)(v15);
+	}
+
+	{
+	std::string iface = "eth0";
+	unsigned int v16 = *((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int *v22[2];
+	v22[0] = eth_ptr + 4;
+	v22[1] = eth_ptr;
+	
+        __gnu_cxx::__exchange_and_add_dispatch((int *) &eth_ptr[1], 1);
+
+        ((void (*)(unsigned int, unsigned int **)) 0x2E810)(v16, v22);
+	if (v22[1])
+		((void (*)(unsigned int *)) 0x3108C)(v22[1]);
+	}
+	
+	{
+	std::string iface = "eth0";
+	unsigned int *v19 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+
+	((void (*)(unsigned int)) 0x287B0)(*v19);
+	}
+
+	(*(void (**)(unsigned int *))(eth_ptr[4] + 40))(eth_ptr + 4);
+
+	((void (*)(unsigned int *)) 0x3108C)(eth_ptr);	
+	
+	return 0;
+}
+
+extern "C" void __attribute__ ((constructor)) init() {
+	unsetenv("LD_PRELOAD");
+	
+	/* expected prologue to 0x49d3c */
+	uint32_t expect_insns[] = {
+		0xe92d4ff0,
+		0xe3019ce8,
+		0xe340900c
+	};
+	if (memcmp((void *)0x49d3c, expect_insns, 12)) {
+		fprintf(stderr, "*** NETSERVICE DOES NOT HAVE EXPECTED BYTE SEQUENCE.  FIRMWARE HAS CHANGED; YOU MUST UPDATE netService_shim.cpp.\n");
+		abort();
+	}
+
+	mprotect((void *)((long)0x00049D3C & ~(sysconf(_SC_PAGESIZE) - 1)), sysconf(_SC_PAGESIZE), PROT_READ | PROT_WRITE | PROT_EXEC);
+	
+	*(uint32_t *) 0x00049D3C = 0xE59F1000;
+	*(uint32_t *) 0x00049D40 = 0xE12FFF11;
+	*(uint32_t *) 0x00049D44 = (uint32_t)create_interfaces;
+}

--- a/bbl_screen-patch/patches/printerui/qml/Screen.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/Screen.qml.patch
@@ -52,7 +52,7 @@
  
      Component.onCompleted: {
          Printer.jumpTo.connect(jumpTo)
-+        X1Plus.awaken(DeviceManager, PrintManager, PrintTask)
++        X1Plus.awaken(DeviceManager, PrintManager, NetworkManager, PrintTask, Network)
      }
  
      Loader {

--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -13,6 +13,7 @@
 .import "./x1plus/Settings.js" as X1PlusSettings
 .import "./x1plus/TempGraph.js" as X1PlusTempGraph
 .import "./x1plus/OTA.js" as X1PlusOTA
+.import "./x1plus/Network.js" as X1PlusNetwork
 
 /* Back-end model logic for X1Plus's UI
  *
@@ -60,6 +61,8 @@ X1Plus.TempGraph = X1PlusTempGraph;
 var TempGraph = X1PlusTempGraph;
 X1Plus.OTA = X1PlusOTA;
 var OTA = X1PlusOTA;
+X1Plus.Network = X1PlusNetwork;
+var Network = X1PlusNetwork;
 
 Stats.X1Plus = X1Plus;
 DDS.X1Plus = X1Plus;
@@ -70,12 +73,15 @@ DBus.X1Plus = X1Plus;
 Settings.X1Plus = X1Plus;
 TempGraph.X1Plus = X1Plus;
 OTA.X1Plus = X1Plus;
+Network.X1Plus = X1Plus;
 
 var _DdsListener = JSDdsListener.DdsListener;
 var _X1PlusNative = JSX1PlusNative.X1PlusNative;
 var DeviceManager = null;
 var PrintManager = null;
+var NetworkManager = null;
 var PrintTask = null;
+var NetworkEnum = null;
 var printerConfigDir = null;
 
 var emulating = _X1PlusNative.getenv("EMULATION_WORKAROUNDS");
@@ -148,11 +154,13 @@ X1Plus.fileExists = fileExists;
  * they are loaded, and they might need to do work touching other modules. 
  * These things happen from 'awaken'.
  */
-function awaken(_DeviceManager, _PrintManager, _PrintTask) {
+function awaken(_DeviceManager, _PrintManager, _NetworkManager, _PrintTask, _Network) {
 	console.log("X1Plus.js awakening");
 	X1Plus.DeviceManager = DeviceManager = _DeviceManager;
 	X1Plus.PrintManager = PrintManager = _PrintManager;
+	X1Plus.NetworkManager = NetworkManager = _NetworkManager;
 	X1Plus.PrintTask = PrintTask = _PrintTask;
+	X1Plus.NetworkEnum = NetworkEnum = _Network;
 	X1Plus.printerConfigDir = printerConfigDir = `/mnt/sdcard/x1plus/printers/${X1Plus.DeviceManager.build.seriaNO}`;
 	_X1PlusNative.system("mkdir -p " + _X1PlusNative.getenv("EMULATION_WORKAROUNDS") + printerConfigDir);
 	Settings.awaken();
@@ -161,6 +169,7 @@ function awaken(_DeviceManager, _PrintManager, _PrintTask) {
 	ShaperCalibration.awaken();
 	GpioKeys.awaken();
 	TempGraph.awaken();
+	Network.awaken();
 	console.log("X1Plus.js is awake");
 }
 

--- a/bbl_screen-patch/patches/printerui/qml/printer/PrintPanel.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/printer/PrintPanel.qml.patch
@@ -1,0 +1,19 @@
+--- printer_ui-orig/printerui/qml/printer/PrintPanel.qml
++++ printer_ui/printerui/qml/printer/PrintPanel.qml
+@@ -4,6 +4,7 @@
+ 
+ import "qrc:/uibase/qml/widgets"
+ import ".."
++import "../X1Plus.js" as X1Plus
+ 
+ MarginPanel {
+     width: 138
+@@ -26,7 +27,7 @@
+     onVisibleChanged: {
+         DeviceManager.activeDeviceInfos(DeviceManager.DI_LED_LIGHT, visible)
+         NetworkManager.getNetworkInfo("wlan0")
+-        if (NetworkManager.wiredNetwork !== undefined) {
++        if (X1Plus.Network.wiredNetwork() !== undefined) {
+             NetworkManager.getNetworkInfo("eth0")
+         }
+         NetworkManager.setNetworkInfoPushOn(visible)

--- a/bbl_screen-patch/patches/printerui/qml/settings/NetworkPage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/settings/NetworkPage.qml.patch
@@ -1,8 +1,10 @@
 --- printer_ui-orig/printerui/qml/settings/NetworkPage.qml
 +++ printer_ui/printerui/qml/settings/NetworkPage.qml
-@@ -6,7 +6,8 @@
+@@ -5,17 +5,19 @@
+ 
  import "qrc:/uibase/qml/widgets"
  import ".."
++import "../X1Plus.js" as X1Plus
  
 -Item {
 +Rectangle {
@@ -10,7 +12,18 @@
  
      property var network: NetworkManager.network
      property bool wifiIsOn: network.isOn && network.powerState
-@@ -29,10 +30,16 @@
+-    property var wiredNetwork: NetworkManager.wiredNetwork
++    property var wiredNetwork: X1Plus.Network.wiredNetwork()
+     property bool wiredIsOn: wiredNetwork.isOn && wiredNetwork.powerState
+     property var wifiNetwork: NetworkManager.wifiNetwork
+     property var wifiListModel: NetworkManager.wifiList
+     property bool hasNetworkSubCard: NetworkManager.networkSubCardState
+-    property bool hasWried: NetworkManager.wiredNetwork !== undefined
++    property bool hasWried: X1Plus.Network.wiredNetwork() !== undefined
+     property bool hasCertificate: NetworkManager.certificateList !== null
+ //    property var currentNetwork: NetworkManager.currentRoute
+ 
+@@ -29,10 +31,16 @@
  
      MarginPanel {
          id: wifiPanel
@@ -30,7 +43,7 @@
  
          Item {
              id: wlanTitle
-@@ -281,13 +288,16 @@
+@@ -281,13 +289,16 @@
  
      MarginPanel {
          id: rightPanel
@@ -52,3 +65,12 @@
          visible: hasNetworkSubCard
  
          Item {
+@@ -439,7 +450,7 @@
+ 
+             Item {
+                 id: infoPanel2
+-                anchors.top: line4.bottom
++                anchors.top: hasCertificate ? line4.bottom : line3.bottom
+                 height: 132
+                 anchors.left: wiredNetworkItem.left
+                 anchors.right: wiredNetworkItem.right

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/Network.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/Network.js
@@ -1,0 +1,74 @@
+.pragma library
+.import "Binding.js" as Binding
+
+/* Mechanism to fake a wiredNetwork even when the bbl_screen C++ does not
+ * want to give it to us
+ *
+ * Copyright (c) 2024 Joshua Wise, and the X1Plus authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var X1Plus = null;
+
+var [_wiredStatus, _onWiredStatus, _setWiredStatus] = Binding.makeBinding(undefined);
+
+function wiredNetwork() {
+	if (!X1Plus.NetworkManager) {
+		console.log("*** Network.js: UGH we lost the race");
+	}
+	if (X1Plus && X1Plus.NetworkManager && X1Plus.NetworkManager.wiredNetwork !== undefined) {
+		return X1Plus.NetworkManager.wiredNetwork;
+	}
+	return _wiredStatus();
+}
+
+function awaken() {
+	X1Plus.DDS.registerHandler("device/inter/report/netservice", function(datum) {
+		/* wiredStatus needs to have:
+		 *   .state (Network.CONNECTED, DISABLE, DISCONNECTED)
+		 *   .isOn
+		 *   .powerState
+		 *   .macAddr
+		 *   .ipv4, .gateway, .mask, .dns, .dns2
+		 *   .isManualDHCP
+		 */
+		if (datum.dev_list) {
+			for (const n of datum.dev_list) {
+				if (n.dev_name != "eth0")
+					continue;
+				
+				let newStatus = {};
+				newStatus.state =
+					n.state == "DISABLE" ? X1Plus.NetworkEnum.DISABLE :
+					n.state == "DISCONNECTED" ? X1Plus.NetworkEnum.DISCONNECTED :
+					n.state == "CONNECTING" ? X1Plus.NetworkEnum.CONNECTING :
+					n.state == "CONFIG" ? X1Plus.NetworkEnum.CONFIG :
+					n.state == "CONNECTED" ? X1Plus.NetworkEnum.CONNECTED :
+					n.state == "CONNECT_FAILED" ? X1Plus.NetworkEnum.CONNECT_FAILED :
+					X1Plus.NetworkEnum.DISCONNECTED;
+				newStatus.isOn = n.net_switch == "ON";
+				newStatus.powerState = n.power_state == "enable";
+				newStatus.isManualDHCP = n.manual_ip;
+				newStatus.macAddr = n.mac;
+				newStatus.ipv4 = n.ip;
+				newStatus.gateway = n.gw;
+				newStatus.mask = n.mask;
+				newStatus.dns = n.dns1;
+				newStatus.dns2 = n.dns2;
+				newStatus.domain = n.domain;
+				_setWiredStatus(newStatus);
+			}
+		}
+	});
+}

--- a/bbl_screen-patch/patches/root.qrc.patch
+++ b/bbl_screen-patch/patches/root.qrc.patch
@@ -128,7 +128,7 @@
  <file>printerui/qml/wizard/Calibrate1Page.qml</file>
  <file>printerui/qml/wizard/CalibratePage.qml</file>
  <file>printerui/qml/wizard/CalibratingPage.qml</file>
-@@ -235,12 +289,31 @@
+@@ -235,12 +289,32 @@
  <file>printerui/qml/wizard/TermsPage.qml</file>
  <file>printerui/qml/wizard/WelcomePage.qml</file>
  <file>printerui/qml/wizard/WizardPage.qml</file>
@@ -143,6 +143,7 @@
 +<file>printerui/qml/x1plus/GcodeGenerator.js</file>
 +<file>printerui/qml/x1plus/GpioKeys.js</file>
 +<file>printerui/qml/x1plus/MeshCalcs.js</file>
++<file>printerui/qml/x1plus/Network.js</file>
 +<file>printerui/qml/x1plus/OTA.js</file>
 +<file>printerui/qml/x1plus/Settings.js</file>
 +<file>printerui/qml/x1plus/ShaperCalibration.js</file>
@@ -160,7 +161,7 @@
  <file>printerui/text/error_texts.sv.json</file>
  <file>printerui/text/error_texts.zh-cn.json</file>
  <file>printerui/text/error_texts.zh-tw.json</file>
-@@ -259,6 +332,9 @@
+@@ -259,6 +333,9 @@
  <file>printerui/text/hms_texts.fr.json</file>
  <file>printerui/text/hms_texts.ja.json</file>
  <file>printerui/text/hms_texts.nl.json</file>
@@ -170,7 +171,7 @@
  <file>printerui/text/hms_texts.sv.json</file>
  <file>printerui/text/hms_texts.zh-cn.json</file>
  <file>printerui/text/hms_texts.zh-tw.json</file>
-@@ -295,3 +371,4 @@
+@@ -295,3 +372,4 @@
  <file>printerui/text/terms.zh-cn.txt</file>
  <file>qt-project.org/imports/QtQuick/VirtualKeyboard/Styles/bbl/style.qml</file>
  </qresource></RCC>

--- a/images/cfw/etc/init.d/S39x1plus_ethernet
+++ b/images/cfw/etc/init.d/S39x1plus_ethernet
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+case "$1" in
+  start)
+    if [ ! -d /sys/class/net/eth0 ]; then
+      # no ethernet at all
+      exit 0
+    fi
+    if [ "$(readlink /sys/class/net/eth0/device/driver)" != "../../../../../../../bus/usb/drivers/smsc95xx" ]; then
+      echo "x1plus_ethernet: found an eth0, but it was not a smsc95xx; assuming it is not an X1Plus expansion board."
+      exit 0
+    fi
+    if [ "$(cat /sys/class/net/eth0/addr_assign_type)" != "1" ]; then
+      echo "x1plus_ethernet: found a smsc95xx eth0, but it does not have a randomly assigned MAC address; not resetting the MAC address."
+      exit 0
+    fi
+    
+    MAC_PROTO=$(bbl_3dpsn 2>/dev/null | md5sum | cut -b1-12)
+
+    # we now have 12 hex bytes -- clear the LSB of the first octet to make
+    # unicast, then set the second LSB to make a LAA
+    MAC_B12345=$(echo $MAC_PROTO | cut -b3-12)
+    MAC_B0=$(printf %02x $((0x$(echo $MAC_PROTO | cut -b1-2) & 0xFE | 0x02)))
+    NEWMAC=$MAC_B0$MAC_B12345
+    echo "x1plus_ethernet: found a smsc95xx eth0 that has a randomly assigned MAC address; resetting to MAC from hash of serial number, $NEWMAC"
+    ifconfig eth0 hw ether $NEWMAC
+    exit 0
+    ;;
+esac

--- a/images/cfw/etc/init.d/S40netService
+++ b/images/cfw/etc/init.d/S40netService
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+start() {
+	printf "Starting netService: "
+	start-stop-daemon -S -m -b -p /var/run/netService.pid \
+		--exec /opt/x1plus/bin/netService_patch \
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+stop() {
+	printf "Stopping netService: "
+	start-stop-daemon -K -q -p /var/run/netService.pid
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+restart() {
+	stop
+    sleep 1
+	start
+}
+
+if [ ! -d "/usr/share/wpa_supplicant" ]; then
+  mkdir /usr/share/wpa_supplicant
+fi
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+	stop
+	;;
+  restart|reload)
+	restart
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?

--- a/images/cfw/etc/init.d/S91device_gate
+++ b/images/cfw/etc/init.d/S91device_gate
@@ -2,7 +2,7 @@
 
 start() {
 	printf "Starting device gate: "
-	export LD_PRELOAD=/opt/x1plus/lib/workaround_ifaddrs.so
+	export LD_PRELOAD=/opt/x1plus/lib/device_gate_shim.so
 	start-stop-daemon -S -m -b -p /var/run/device_gate.pid \
 		--exec /usr/bin/device_gate \
 	[ $? = 0 ] && echo "OK" || echo "FAIL"

--- a/images/cfw/opt/x1plus/bin/netService_patch
+++ b/images/cfw/opt/x1plus/bin/netService_patch
@@ -1,0 +1,2 @@
+#!/bin/sh
+LD_PRELOAD=/opt/x1plus/lib/netService_shim.so exec /usr/bin/netService "$@"

--- a/images/cfw/opt/x1plus/lib/netService_shim.so
+++ b/images/cfw/opt/x1plus/lib/netService_shim.so
@@ -1,0 +1,1 @@
+../../../../../bbl_screen-patch/netService_shim.so


### PR DESCRIPTION
In theory, only the X1E has support for Ethernet.  As it turns out, vestiges of this support live in the X1 Carbon firmware, but it needs some help.  To help it out, we:

* Interpose `libbbl_utils`, which, on X1 Carbon, doesn't know that `eth0` being up means that the network could be up.  `device_gate` needs to know this in order to be willing to connect to the cloud over Ethernet (thanks @balika011).
* Binary-patch `netService`, which doesn't know to create an `eth0` route on X1 Carbon, but can be convinced to with a little bit of help (thanks @balika011).
* Look for the X1Plus Expansion Board on boot, and if one is connected that doesn't have a MAC address in its EEPROM, assign an LAA based on the printer serial number so we get a consistent IP address each time we boot.
* Write some QML to listen to `netService`, because `bbl_screen` does not know how to listen for a `NetworkManager.wiredNetwork`; we create an `X1Plus.Network.wiredNetwork()` interface that looks a lot like a `NetworkManager.wiredNetwork` in response to `netService` DDS events, and replace JavaScript lookups of `NetworkManager.wiredNetwork` to point to this interface.

This allows X1 Carbons augmented with a USB Ethernet adapter of any kind (including an X1Plus Expansion Board) to use the native X1E Ethernet infrastructure to connect instead of WiFi, and provides the X1E GUI when an `eth0` interface of some kind is present.