### PR TITLE
add device_gate_shim.so symlink

### DIFF
--- a/images/cfw/opt/x1plus/lib/device_gate_shim.so
+++ b/images/cfw/opt/x1plus/lib/device_gate_shim.so
@@ -1,0 +1,1 @@
+../../../../../bbl_screen-patch/device_gate_shim.so


### PR DESCRIPTION
Oops.  This got lost in the Ethernet PR, but without it, the printer won't connect to the cloud over Ethernet.