### PR TITLE
x1plusd: add a httpd with a simple websocket-to-DBus interface

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -7,6 +7,7 @@ from .dbus import *
 from .settings import SettingsService
 from .ota import OTAService
 from .sshd import SSHService
+from .httpd import HTTPService
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +19,11 @@ async def main():
     settings = SettingsService(router=router)
     ota = OTAService(router=router, settings=settings)
     ssh = SSHService(settings=settings)
+    httpd = HTTPService(router=router, settings=settings)
 
     asyncio.create_task(settings.task())
     asyncio.create_task(ota.task())
+    asyncio.create_task(httpd.task())
     if settings.get("polar_cloud", False):
         from .polar_cloud import PolarPrintService
         polar_cloud = PolarPrintService(settings=settings)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
@@ -98,6 +98,8 @@ class HTTPService():
                 await ws.send_json(rv)
         except Exception as e:
             logger.error(f"websocket had exception {e}")
+            import traceback
+            traceback.print_exception(e)
             await ws.close()
 
         logger.info("goodbye, websocket")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import asyncio
+from pathlib import Path
 
 import aiohttp
 from aiohttp import web
@@ -22,7 +23,13 @@ class HTTPService():
         self.runner = None
         self.site = None
         self.app = web.Application()
-        self.app.add_routes([web.get('/', self.route_hello), web.get('/ws', self.route_websocket)])
+        
+        if x1plus.utils.is_emulating():
+            static_path = Path(__file__).resolve().parent.parent.parent.parent.parent.parent / 'share' / 'www'
+        else:
+            static_path = "/opt/x1plus/share/www"
+        logger.info(f"x1plus httpd will serve from {static_path}")
+        self.app.add_routes([web.get('/hello', self.route_hello), web.get('/ws', self.route_websocket), web.static("/", static_path)])
     
     async def route_hello(self, request):
         return web.Response(text="Hello, world")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
@@ -1,0 +1,122 @@
+import os
+import subprocess
+import asyncio
+
+import aiohttp
+from aiohttp import web
+
+import x1plus.utils
+from .dbus import *
+from jeepney import DBusAddress, new_method_call, MessageType
+
+logger = logging.getLogger(__name__)
+access_logger = logging.getLogger(__name__ + ".access")
+
+PROTOCOL_VERSION = 0
+
+class HTTPService():
+    def __init__(self, settings, router, **kwargs):
+        self.x1psettings = settings
+        self.x1psettings.on("http.enabled", lambda: asyncio.create_task(self.sync_startstop()))
+        self.router = router
+        self.runner = None
+        self.site = None
+        self.app = web.Application()
+        self.app.add_routes([web.get('/', self.route_hello), web.get('/ws', self.route_websocket)])
+    
+    async def route_hello(self, request):
+        return web.Response(text="Hello, world")
+    
+    async def route_websocket(self, request):
+        ws = web.WebSocketResponse(autoping=True, heartbeat=10)
+        await ws.prepare(request)
+        
+        access_logger.info("websocket is connecting")
+        
+        try:
+            await ws.send_json({"jsonrpc": "2.0", "method": "hello", "params": { "x1plus_protocol_version": PROTOCOL_VERSION }})
+            
+            # the first packet should be an auth packet; we just special
+            # case this, I suppose
+            authpkt = await ws.receive_json()
+            try:
+                assert authpkt["method"] == "auth"
+                assert 'id' in authpkt
+                password = authpkt["params"]["password"]
+            except Exception as e:
+                await ws.send_json({"jsonrpc": "2.0", "error": {"code": -32601, "message": "first packet must be a valid auth packet"}})
+                await ws.close()
+                return ws
+            
+            system_password = self.x1psettings.get('http.password', None)
+            if system_password is None: # we have to do it the hard way, I guess
+                with open('/config/device/access_token', 'r') as f:
+                    system_password = f.read().strip()
+            if system_password != "" and password != system_password:
+                await ws.send_json({"jsonrpc": "2.0", "error": {"code": -1, "message": "permission denied"}, "id": authpkt['id']})
+                await ws.close()
+                return ws
+            await ws.send_json({"jsonrpc": "2.0", "result": 0, "id": authpkt['id']})
+
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    logger.error(f"websocket died with exception {ws.exception()}")
+                    break
+                
+                # all exceptions here will get handled by the top level exception handler
+                assert msg.type == aiohttp.WSMsgType.TEXT
+                pkt = msg.json()
+                
+                # all jsonrpc messages are RPCs here, not notifications, and so they should all have IDs
+                assert pkt['jsonrpc'] == '2.0'
+                assert pkt['id']
+                rv = {'jsonrpc': '2.0', 'id': pkt['id']}
+                if pkt['method'] == 'dbus.call':
+                    try:
+                        addr = DBusAddress(pkt['params']['object'], bus_name=pkt['params']['bus_name'], interface=pkt['params']['interface'])
+                        method = pkt['params']['method']
+                        params = pkt['params']['params']
+                    except Exception as e:
+                        pkt['error'] = {'code': -32602, 'message': str(e)}
+                        await ws.send_json(rv)
+                        continue
+                    dmsg = new_method_call(addr, method, 's', (json.dumps(params), ))
+                    reply = await self.router.send_and_get_reply(dmsg)
+                    if reply.header.message_type == MessageType.error:
+                        rv['error'] = {'code': 1, 'message': reply.header.fields.get(HeaderFields.error_name, 'unknown-error') }
+                    else:
+                        rv['result'] = json.loads(reply.body[0])
+                else:
+                    pkt['error'] = {'code': -32601, 'message': 'method not found'}
+                await ws.send_json(rv)
+        except Exception as e:
+            logger.error(f"websocket had exception {e}")
+            await ws.close()
+
+        logger.info("goodbye, websocket")
+        return ws
+    
+    async def task(self):
+        await self.sync_startstop()
+
+    async def sync_startstop(self):
+        enabled = self.x1psettings.get("http.enabled", False)
+        
+        if self.site and not enabled:
+            await self.site.stop()
+            self.site = None
+        
+        if self.runner and not enabled:
+            await self.runner.cleanup()
+            self.runner = None
+        
+        if enabled and not self.runner:
+            self.runner = web.AppRunner(self.app, access_log=access_logger, logger=logger)
+            await self.runner.setup()
+        
+        if enabled and not self.site:
+            bind_addr = self.x1psettings.get("http.bind.addr", "0.0.0.0")
+            bind_port = self.x1psettings.get("http.bind.port", 80)
+            self.site = web.TCPSite(self.runner, bind_addr, bind_port)
+            await self.site.start()
+            logger.info(f"X1Plusd httpd is running on {bind_addr}:{bind_port}")


### PR DESCRIPTION
We use the `aiohttp` library to add a simple HTTP server that serves some static files (for now, none are actually provided) as well as a WebSocket that provides a JSONRPC interface.  The WebSocket authenticates with a similar mechanism to the VNC password -- i.e., it either grabs a password from the configuration, or it uses the access code.  For now, we provide only one JSONRPC method (after authentication), `dbus.call`, which synchronously (to the websocket) calls an arbitrary DBus method using the Bambu calling convention.

Any exception in the WebSocket is handled gracelessly (i.e., it is logged to syslog, and the connection is instantly dropped).

A sample WebSocket client is shown [here](https://github.com/jwise/x1plusweb/); you can use it online [here](https://jwise.github.io/x1plusweb/) to connect to your printer, but note that you will have to [enable insecure websockets as appropriate for your browser](https://www.damirscorner.com/blog/posts/20210528-allowinginsecurewebsocketconnections.html) when using the GitHub Pages-hosted version.

Future work is to add a mechanism to glue DBus signals and MQTT events into the WebSocket, and to pull in the latest build (or a tagged build, anyway) of x1plusweb when building a .x1p.