### PR TITLE
Hook up PrintOptionsPage.qml settings to x1plus settings

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -87,7 +87,6 @@ var printerConfigDir = null;
 var emulating = _X1PlusNative.getenv("EMULATION_WORKAROUNDS");
 X1Plus.emulating = emulating;
 
-
 function isIdle() {
 	return PrintManager.currentTask.stage < PrintTask.WORKING;
 }
@@ -148,6 +147,18 @@ function fileExists(fPath) {
 }
 X1Plus.fileExists = fileExists;
 
+_LayerUpdate = null;
+_PrintStateUpdate = null;
+
+function onStateChanged(a) {
+	_PrintStateUpdate({["state"]: a});
+}
+X1Plus.onStateChanged = onStateChanged;
+
+function onLayerChanged(a, b) {
+	_LayerUpdate({["layerNum"]: a,["totalLayerNum"]: b});
+}
+X1Plus.onLayerChanged = onLayerChanged;
 /* Some things can only happen after we have a DeviceManager and
  * PrintManager passed down, and the real QML environment is truly alive. 
  * Submodules also don't get access to the global X1Plus object until after
@@ -171,7 +182,10 @@ function awaken(_DeviceManager, _PrintManager, _NetworkManager, _PrintTask, _Net
 	TempGraph.awaken();
 	Network.awaken();
 	console.log("X1Plus.js is awake");
+	_LayerUpdate = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/status", "x1plus.status", "Layer");
+	_PrintStateUpdate = X1Plus.DBus.proxyFunction("x1plus.x1plusd", "/x1plus/status", "x1plus.status", "State");
 }
+
 
 X1Plus.DBus.registerMethod("ping", (param) => {
 	param["pong"] = "from QML";

--- a/bbl_screen-patch/patches/printerui/qml/printer/PrintListener.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/printer/PrintListener.qml.patch
@@ -1,6 +1,31 @@
 --- printer_ui-orig/printerui/qml/printer/PrintListener.qml
 +++ printer_ui/printerui/qml/printer/PrintListener.qml
-@@ -39,6 +39,10 @@
+@@ -1,14 +1,23 @@
+ import QtQuick 2.12
+ import Printer 1.0
++import "../X1Plus.js" as X1Plus
+ 
+ Item {
+ 
+     property bool printing: PrintManager.currentTask.stage >= PrintTask.WORKING
+     property var printState: PrintManager.currentTask.state
+-
++    property var layerNum: PrintManager.currentTask.layerNum
++    
+     onPrintingChanged: {
+         DeviceManager.power.externalWakeup()
+     }
++    onLayerNumChanged:{
++        X1Plus.onLayerChanged(layerNum,PrintManager.currentTask.totalLayerNum); 
++    }
++
++    onPrintStateChanged: {
++        X1Plus.onStateChanged(printState);
++    }
+ 
+     Shortcut {
+         sequences: ["Stop", "Ctrl+B"]
+@@ -39,6 +48,10 @@
                  }
              }
  

--- a/bbl_screen-patch/patches/printerui/qml/printer/PrintOptionsPage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/printer/PrintOptionsPage.qml.patch
@@ -1,0 +1,84 @@
+--- printer_ui-orig/printerui/qml/printer/PrintOptionsPage.qml
++++ printer_ui/printerui/qml/printer/PrintOptionsPage.qml
+@@ -5,11 +5,17 @@
+ 
+ import "qrc:/uibase/qml/widgets"
+ import ".."
+-
++import "../X1Plus.js" as X1Plus
+ Item {
+ 
+     property var printConfig: PrintManager.printConfig
+     property var doorOpenLevelModel: [qsTr("notification"), qsTr("pause printing")]
++    property bool isPrintingMonitorOn: X1Plus.Settings.get("printer.isPrintingMonitorOn", printConfig.isPrintingMonitorOn)
++    property int printSensitiveMode: X1Plus.Settings.get("printer.printSensitiveMode", printConfig.printSensitiveMode)
++    property bool isBuildPlateMarkerOn: X1Plus.Settings.get("printer.isBuildPlateMarkerOn", printConfig.isBuildPlateMarkerOn)
++    property bool isFirstLayerOn: X1Plus.Settings.get("printer.isFirstLayerOn", printConfig.isFirstLayerOn)
++    property bool isStepLossRecoveryOn: X1Plus.Settings.get("printer.isStepLossRecoveryOn", printConfig.isStepLossRecoveryOn)
++    property bool isSDCardCache3mfOn: X1Plus.Settings.get("printer.isSDCardCache3mfOn", printConfig.isSDCardCache3mfOn)
+ 
+     ScrollView {
+         id: scroll
+@@ -42,7 +48,7 @@
+                     anchors.top: parent.top
+                     anchors.left: parent.left
+                     anchors.leftMargin: 27
+-                    dynamicChecked: printConfig.isPrintingMonitorOn
++                    dynamicChecked: isPrintingMonitorOn
+                     textColor: StateColors.get("gray_100")
+                     textWrapMode: Text.WordWrap
+                     font: Fonts.body_30
+@@ -77,7 +83,7 @@
+                     anchors.leftMargin: 3
+                     model: printConfig.printSensitiveStrings
+                     textColor: Colors.brand
+-                    currentIndex: printConfig.printSensitiveMode
++                    currentIndex: printSensitiveMode
+                     visible: printMonitorCheckBox.checked
+ 
+                     onCurrentIndexChanged: {
+@@ -86,7 +92,7 @@
+                         }
+                     }
+                     Binding on currentIndex {
+-                        value: printConfig.printSensitiveMode
++                        value: printSensitiveMode
+                     }
+                 }
+             }
+@@ -106,7 +112,7 @@
+                     anchors.top: parent.top
+                     anchors.left: parent.left
+                     anchors.leftMargin: 27
+-                    dynamicChecked: printConfig.isBuildPlateMarkerOn
++                    dynamicChecked: isBuildPlateMarkerOn
+                     textColor: StateColors.get("gray_100")
+                     textWrapMode: Text.WordWrap
+                     font: Fonts.body_30
+@@ -146,7 +152,7 @@
+                     anchors.top: parent.top
+                     anchors.left: parent.left
+                     anchors.leftMargin: 27
+-                    dynamicChecked: printConfig.isFirstLayerOn
++                    dynamicChecked: isFirstLayerOn
+                     textColor: StateColors.get("gray_100")
+                     font: Fonts.body_30
+                     text: qsTr("First Layer Inspection")
+@@ -170,7 +176,7 @@
+                     anchors.top: parent.top
+                     anchors.left: parent.left
+                     anchors.leftMargin: 27
+-                    dynamicChecked: printConfig.isStepLossRecoveryOn
++                    dynamicChecked: isStepLossRecoveryOn
+                     textColor: StateColors.get("gray_100")
+                     font: Fonts.body_30
+                     text: qsTr("Auto-recovery from step loss")
+@@ -279,7 +285,7 @@
+                     anchors.top: parent.top
+                     anchors.left: parent.left
+                     anchors.leftMargin: 27
+-                    dynamicChecked: printConfig.isSDCardCache3mfOn
++                    dynamicChecked: isSDCardCache3mfOn
+                     textColor: StateColors.get("gray_100")
+                     font: Fonts.body_30
+                     text: qsTr("Caching cloud print files to sdcard")


### PR DESCRIPTION
Print config settings are now keys in settings.json. Here are the keys:

bool printer.isPrintingMonitorOn
int printer.printSensitiveMode
bool printer.isBuildPlateMarkerOn
bool printer.isFirstLayerOn
bool printer.isStepLossRecoveryOn
bool printer.isSDCardCache3mfOn

Also layer change and print state change signals have been hooked up to a DBus.proxyFunction() to expose these signals to x1plusd