### PR TITLE
x1plusd: add MQTT client

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -8,6 +8,7 @@ from .settings import SettingsService
 from .ota import OTAService
 from .sshd import SSHService
 from .httpd import HTTPService
+from .mqtt import MQTTClient
 
 logger = logging.getLogger(__name__)
 
@@ -17,10 +18,12 @@ async def main():
 
     router = await get_dbus_router()
     settings = SettingsService(router=router)
+    mqtt = MQTTClient(settings=settings)
     ota = OTAService(router=router, settings=settings)
     ssh = SSHService(settings=settings)
     httpd = HTTPService(router=router, settings=settings)
 
+    asyncio.create_task(mqtt.task())
     asyncio.create_task(settings.task())
     asyncio.create_task(ota.task())
     asyncio.create_task(httpd.task())

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -21,7 +21,7 @@ async def main():
     mqtt = MQTTClient(settings=settings)
     ota = OTAService(router=router, settings=settings)
     ssh = SSHService(settings=settings)
-    httpd = HTTPService(router=router, settings=settings)
+    httpd = HTTPService(router=router, settings=settings, mqtt=mqtt)
 
     asyncio.create_task(mqtt.task())
     asyncio.create_task(settings.task())

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -6,6 +6,8 @@ import ssl
 import json
 import contextlib
 
+import x1plus.utils
+
 logger = logging.getLogger(__name__)
 
 class MQTTClient():
@@ -41,14 +43,7 @@ class MQTTClient():
             else:
                 logger.warning(f"message on unexpected topic {message.topic}?")
     
-    async def bullshit(self):
-        with self.report_messages() as q:
-            while True:
-                v = await q.get()
-                print(v)
-    
     async def task(self):
-        bullshit = asyncio.create_task(self.bullshit())
         while True:
             try:
                 logger.info("connecting to MQTT broker")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -1,0 +1,74 @@
+import os
+import aiomqtt
+import asyncio
+import logging
+import ssl
+import json
+
+logger = logging.getLogger(__name__)
+
+class MQTTClient():
+    def __init__(self, settings, **kwargs):
+        self.x1psettings = settings
+        
+        self.x1psettings.on("mqtt.override.host", lambda: self._trigger_reconnect())
+        self.x1psettings.on("mqtt.override.password", lambda: self._trigger_reconnect())
+        self.x1psettings.on("mqtt.override.sn", lambda: self._trigger_reconnect())
+        
+        self.mqttc = None
+        self.reconnect_event = asyncio.Event()
+    
+    def _trigger_reconnect(self):
+        self.reconnect_event.set()
+    
+    async def mqtt_message_loop(self):
+        async for message in self.mqttc.messages:
+            print(message.topic, json.loads(message.payload))
+    
+    async def task(self):
+        while True:
+            try:
+                logger.info("connecting to MQTT broker")
+                
+                password = None
+                if os.path.isfile("/config/device/access_token"):
+                    password = open("/config/device/access_token", "r").read()
+                password = self.x1psettings.get("mqtt.override.password", password)
+                
+                ssl_ctx = ssl.create_default_context()
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+
+                client = aiomqtt.Client(
+                    hostname = self.x1psettings.get("mqtt.override.host", "127.0.0.1"),
+                    port = 8883,
+                    username = "bblp",
+                    password = password,
+                    tls_context = ssl_ctx,
+                    tls_insecure = True)
+                self.reconnect_event.clear()
+                async with client:
+                    await client.subscribe("device/+/request")
+                    await client.subscribe("device/+/report")
+                    self.mqttc = client
+                    loop_task = asyncio.create_task(self.mqtt_message_loop())
+                    await asyncio.wait([loop_task, self.reconnect_event.wait()], return_when=asyncio.FIRST_COMPLETED)
+                    loop_task.cancel()
+            except aiomqtt.MqttError as e:
+                self.mqttc = None
+                logger.warning(f"MQTT connection lost: {e}")
+                await asyncio.sleep(5)
+            finally:
+                self.mqttc = None
+
+    async def publish_request(self, obj):
+        pass
+    
+    async def publish_report(self, obj):
+        pass
+    
+    async def on_request(self, fn):
+        pass
+    
+    async def on_report(self, fn):
+        pass


### PR DESCRIPTION
This PR adds an MQTT client using `aiohttp` to `x1plusd`, and an internal interface to subscribe to MQTT messages.  It adds a sample client that subscribes to MQTT messages and forwards them to the httpd websocket.  The MQTT client can be configured to connect to a non-local MQTT server (for instance, if you are running `x1plusd` in emulation, and want it to talk to a real printer for status) using the `mqtt.override.*` settings.

For instance, when running in emulation, consider:

```
$ PYTHONPATH=../lib/python/ ./x1plus settings get
http.bind.port: 8080
http.enabled: true
http.password: "lol"
mqtt.override.host: "10.1.10.50"
mqtt.override.password: "[printer access code]"
mqtt.override.sn: "[printer serial number]"
$ websocat ws://127.0.0.1:8080/ws
{"jsonrpc": "2.0", "method": "hello", "params": {"x1plus_protocol_version": 0}}
{"jsonrpc": "2.0", "method": "auth", "params": {"password": "lol"}, "id": 0}
{"jsonrpc": "2.0", "result": 0, "id": 0}
```

... and you should begin receiving `mqtt.notify` jsonrpc events.  

There are a handful of useful things to do from here as future work:
* `x1plusd` probably should gain an internal status accumulator that listens to messages over MQTT, and buffers the answers as needed to be able to answer over DBus to an `x1plus.client` that wants to know how things are going.
* The Polar Cloud plugin should use the buffered status accumulator to report status to the cloud, and should subscribe to messages.
* The "wait-multiple-queues-or-generators" thing probably is going to be useful in a way that should be refactored.
* More proximately, I wanted to use the status indication in order to drive LEDs on the expansion board.  So I'm going to do that next.

Thanks to @jphannifan for early work on figuring out how to drive `aiomqtt`!