### PR TITLE
x1plus.mqtt: fix compatibility issue with python 3.12 that prevents x1plusd from starting up on printer python

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -74,7 +74,7 @@ class MQTTClient():
                     await client.subscribe("device/+/report")
                     self.mqttc = client
                     loop_task = asyncio.create_task(self.mqtt_message_loop())
-                    await asyncio.wait([loop_task, self.reconnect_event.wait()], return_when=asyncio.FIRST_COMPLETED)
+                    await asyncio.wait([loop_task, asyncio.ensure_future(self.reconnect_event.wait())], return_when=asyncio.FIRST_COMPLETED)
                     loop_task.cancel()
                     try:
                         await loop_task


### PR DESCRIPTION
Oopsies.  Fixes:

```
[2024-07-14 08:46:59,923] x1plus.services.x1plusd: ERROR: exception in coroutine: Task exception was never retrieved Passing coroutines is forbidden, use tasks explicitly.
Task exception was never retrieved
future: <Task finished name='Task-4' coro=<MQTTClient.task() done, defined at /opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py:46> exception=TypeError('Passing coroutines is forbidden, use tasks explicitly.')>
Traceback (most recent call last):
  File "/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py", line 77, in task
    await asyncio.wait([loop_task, self.reconnect_event.wait()], return_when=asyncio.FIRST_COMPLETED)
  File "/opt/python/lib/python3.12/asyncio/tasks.py", line 461, in wait
    raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
TypeError: Passing coroutines is forbidden, use tasks explicitly.
```

Mea culpa.