### PR TITLE
Add X1Plus Expansion Board support to x1plusd.

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -14,26 +14,36 @@ from .sensors import SensorsService
 
 logger = logging.getLogger(__name__)
 
-async def main():
-    logger.info("x1plusd is starting up")
+class X1PlusDaemon:
+    @classmethod
+    async def create(cls):
+        # must be a classmethod, since __init__ cannot be async
+        self = X1PlusDaemon()
 
-    router = await get_dbus_router()
-    settings = SettingsService(router=router)
-    mqtt = MQTTClient(settings=settings)
-    ota = OTAService(router=router, settings=settings)
-    ssh = SSHService(settings=settings)
-    httpd = HTTPService(router=router, settings=settings, mqtt=mqtt)
-    sensors = SensorsService(router=router, settings=settings)
-    expansion = ExpansionManager(settings=settings, sensors=sensors)
+        logger.info("creating x1plusd services")
+        self.router = await get_dbus_router()
+        self.settings = SettingsService(router=self.router)
+        self.mqtt = MQTTClient(daemon=self)
+        self.ota = OTAService(router=self.router, daemon=self)
+        self.ssh = SSHService(daemon=self)
+        self.httpd = HTTPService(router=self.router, daemon=self)
+        self.sensors = SensorsService(router=self.router, daemon=self)
+        self.expansion = ExpansionManager(daemon=self)
+        if not self.settings.get("polar_cloud", False):
+            self.polar_cloud = None
+        else:
+            from .polar_cloud import PolarPrintService
+            self.polar_cloud = PolarPrintService(daemon=self)
+        
+        return self
 
-    asyncio.create_task(mqtt.task())
-    asyncio.create_task(settings.task())
-    asyncio.create_task(ota.task())
-    asyncio.create_task(httpd.task())
-    asyncio.create_task(sensors.task())
-    if settings.get("polar_cloud", False):
-        from .polar_cloud import PolarPrintService
-        polar_cloud = PolarPrintService(settings=settings)
-        asyncio.create_task(polar_cloud.begin())
+    async def start(self):
+        asyncio.create_task(self.mqtt.task())
+        asyncio.create_task(self.settings.task())
+        asyncio.create_task(self.ota.task())
+        asyncio.create_task(self.httpd.task())
+        asyncio.create_task(self.sensors.task())
+        if self.polar_cloud:
+            asyncio.create_task(self.polar_cloud.begin())
 
-    logger.info("x1plusd is running")
+        logger.info("x1plusd is running")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -10,6 +10,7 @@ from .sshd import SSHService
 from .httpd import HTTPService
 from .mqtt import MQTTClient
 from .expansion import ExpansionManager
+from .sensors import SensorsService
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +23,14 @@ async def main():
     ota = OTAService(router=router, settings=settings)
     ssh = SSHService(settings=settings)
     httpd = HTTPService(router=router, settings=settings, mqtt=mqtt)
-    expansion = ExpansionManager(settings=settings)
+    sensors = SensorsService(router=router, settings=settings)
+    expansion = ExpansionManager(settings=settings, sensors=sensors)
 
     asyncio.create_task(mqtt.task())
     asyncio.create_task(settings.task())
     asyncio.create_task(ota.task())
     asyncio.create_task(httpd.task())
+    asyncio.create_task(sensors.task())
     if settings.get("polar_cloud", False):
         from .polar_cloud import PolarPrintService
         polar_cloud = PolarPrintService(settings=settings)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -9,9 +9,9 @@ from .ota import OTAService
 from .sshd import SSHService
 from .httpd import HTTPService
 from .mqtt import MQTTClient
+from .expansion import ExpansionManager
 
 logger = logging.getLogger(__name__)
-
 
 async def main():
     logger.info("x1plusd is starting up")
@@ -22,6 +22,7 @@ async def main():
     ota = OTAService(router=router, settings=settings)
     ssh = SSHService(settings=settings)
     httpd = HTTPService(router=router, settings=settings, mqtt=mqtt)
+    expansion = ExpansionManager(settings=settings)
 
     asyncio.create_task(mqtt.task())
     asyncio.create_task(settings.task())

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -28,7 +28,7 @@ class X1PlusDaemon:
         self.ssh = SSHService(daemon=self)
         self.httpd = HTTPService(router=self.router, daemon=self)
         self.sensors = SensorsService(router=self.router, daemon=self)
-        self.expansion = ExpansionManager(daemon=self)
+        self.expansion = ExpansionManager(router=self.router, daemon=self)
         if not self.settings.get("polar_cloud", False):
             self.polar_cloud = None
         else:
@@ -43,6 +43,7 @@ class X1PlusDaemon:
         asyncio.create_task(self.ota.task())
         asyncio.create_task(self.httpd.task())
         asyncio.create_task(self.sensors.task())
+        asyncio.create_task(self.expansion.task())
         if self.polar_cloud:
             asyncio.create_task(self.polar_cloud.begin())
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__main__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__main__.py
@@ -2,7 +2,7 @@ import asyncio
 import logging, logging.handlers
 import setproctitle
 
-from . import main, logger
+from . import X1PlusDaemon, logger
 
 setproctitle.setproctitle(__spec__.name)
 
@@ -28,10 +28,14 @@ def exceptions(loop, ctx):
         pass
 
 
+async def start():
+    x1plusd = await X1PlusDaemon.create()
+    await x1plusd.start()
+
 # TODO: check if we are already running
 loop = asyncio.new_event_loop()
 loop.set_exception_handler(exceptions)
-loop.create_task(main())
+loop.create_task(start())
 try:
     loop.run_forever()
 finally:

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion.py
@@ -1,0 +1,67 @@
+import os
+import logging
+
+from collections import namedtuple
+import usb
+
+# workaround for missing ldconfig
+def find_library(lib):
+    p = f"/usr/lib/{lib}.so"
+    if os.path.exists(p):
+        return p
+import usb.backend.libusb1
+usb.backend.libusb1.get_backend(find_library=find_library)
+
+logger = logging.getLogger(__name__)
+
+ExpansionDevice = namedtuple('ExpansionDevice', [ 'revision', 'serial', 'ftdidev' ])
+
+def detect_x1p_002_b01():
+    """
+    Looks for a X1P-002-B01.
+    
+    If it finds one, returns an ExpansionDevice.
+    """
+    
+    lan9514_eth = usb.core.find(idVendor = 0x0424, idProduct = 0xec00)
+    if not lan9514_eth:
+        return None
+    
+    if lan9514_eth.product == 'Expansion Board X1P-002-B01':
+        revision = lan9514_eth.product.split(' ')[2]
+        serial = lan9514_eth.serial_number
+    else:
+        # Maybe it hasn't been serialized; I guess we will limp along in the
+        # mean time, and hope that we can find a sibling FTDI.
+        logger.warning("found a LAN9514, but it does not appear to be an X1P-002-B01?")
+        revision = 'Unknown'
+        serial = 'Unknown'
+    
+    # Look for a sibling FTDI device.
+    ftdidev = usb.core.find(custom_match = lambda d: d.parent == lan9514_eth.parent, idVendor = 0x0403)
+    if not ftdidev:
+        logger.warning("found a LAN9514, but no FTDI sibling")
+        return None
+    
+    return ExpansionDevice(revision = revision, serial = serial, ftdidev = ftdidev)
+
+class ExpansionManager():
+    def __init__(self, settings, **kwargs):
+        # We only have to look for an expansion board on boot, since it
+        # can't be hot-installed.
+        self.expansion = detect_x1p_002_b01()
+        if not self.expansion:
+            logger.info("no X1Plus expansion board detected")
+            return
+        
+        logger.info(f"found X1Plus expansion board serial {self.expansion.serial}")
+        
+        # later: detect each port on the FTDI to determine if it has an
+        # attached eeprom
+        
+        # later: register expansion.port_n for each port on the ftdidev with
+        # settings to call update_drivers
+        self.update_drivers()
+    
+    def update_drivers(self):
+        pass

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/__init__.py
@@ -1,0 +1,1 @@
+from .manager import ExpansionManager

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/detect_eeprom.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/detect_eeprom.py
@@ -1,0 +1,133 @@
+"""
+
+The X1Plus expansion-expansion boards have a 24C02 EEPROM attached with
+SCL=D7, SDA=D6.  We bit-bang this with the MPSSE engine, since there's no
+actual I2C engine hooked up to those pins.
+
+"""
+
+import logging
+
+from pyftdi.ftdi import Ftdi
+
+logger = logging.getLogger(__name__)
+
+
+# SCL = 0x80
+# SDA = 0x40
+
+start_and_addr = bytes([
+    Ftdi.SET_BITS_LOW, 0x00, 0x00,
+    Ftdi.SET_BITS_LOW, 0x00, 0x00,
+    Ftdi.SET_BITS_LOW, 0x00, 0x00, # start sequence: SCL = 1, SDA = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # start sequence: SCL = 1, SDA = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # start sequence: SCL = 0, SDA = 0
+    
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0: address
+    Ftdi.SET_BITS_LOW, 0x00, 0x00, # SDA = 1, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0
+
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # SDA = 0, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x00, # SDA = 1, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0
+    
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # SDA = 0, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # SDA = 0, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # SDA = 0, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # SDA = 0, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+])
+
+writezero = bytes([
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0: write
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # SDA = 0, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # SDA = 0, SCL = 0
+])
+
+writeone = bytes([
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0: write
+    Ftdi.SET_BITS_LOW, 0x00, 0x00, # SDA = 1, SCL = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0
+])
+
+readbit = bytes([
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x00, # SDA = 1, SCL = 1: read ACK
+    Ftdi.GET_BITS_LOW,
+    Ftdi.SET_BITS_LOW, 0x00, 0x80, # SDA = 1, SCL = 0
+])
+
+stop = bytes([
+    Ftdi.SET_BITS_LOW, 0x00, 0xC0, # stop sequence: SCL = 0, SDA = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x40, # stop sequence: SCL = 1, SDA = 0
+    Ftdi.SET_BITS_LOW, 0x00, 0x00, # stop sequence: SCL = 1, SDA = 1
+    Ftdi.SET_BITS_LOW, 0x00, 0x00,
+    Ftdi.SET_BITS_LOW, 0x00, 0x00,
+
+    Ftdi.SEND_IMMEDIATE])
+
+def detect_eeprom(ftdipath):
+    ftdi = Ftdi()
+    ftdi.open_mpsse_from_url(ftdipath, frequency=50000)
+    ftdi.purge_buffers()
+    ftdi.enable_adaptive_clock(False)
+
+    # Write address 0x00.
+    cmd = bytearray()
+    cmd += start_and_addr
+    cmd += writezero # write
+    cmd += readbit # ACK
+    for i in range(8):
+        cmd += writezero # write 0 for address
+    cmd += readbit # ACK
+    cmd += stop
+
+    ftdi.write_data(cmd)
+    rd = ftdi.read_data_bytes(2, 4)
+    if rd[0] & 0x40:
+        logger.info(f"NACK for device address on {ftdipath}")
+        return None
+    if rd[0] & 0x40:
+        logger.info(f"NACK for write address 0 on {ftdipath}")
+        return None
+
+    # Read a byte.
+
+    cmd = bytearray()
+    cmd += start_and_addr
+    cmd += writeone # read
+    cmd += readbit # ACK
+    for i in range(8):
+        cmd += readbit
+    cmd += stop
+
+    rbs = bytearray()
+    for i in range(256):
+        ftdi.write_data(cmd)
+        rd = ftdi.read_data_bytes(9, 4)
+        if rd[0] & 0x40:
+            logger.info(f"NACK for read byte {i} on {ftdipath}")
+            return None
+        b = 0
+        for d in rd[1:9]:
+            b <<= 1
+            b |= 1 if d & 0x40 else 0
+        rbs.append(b)
+
+    ftdi.close()
+    
+    return rbs

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -4,7 +4,6 @@ import logging
 import pyftdi.i2c
 import binascii
 
-import usb.util
 import asyncio
 import time
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -1,0 +1,75 @@
+import os
+import logging
+
+import pyftdi.i2c
+import binascii
+
+import usb.util
+import asyncio
+
+logger = logging.getLogger(__name__)
+
+class I2cDriver():
+    DEVICE_DRIVERS = {}
+    
+    def __init__(self, manager, config, ftdi_path):
+        self.i2c = pyftdi.i2c.I2cController()
+        self.i2c.configure(ftdi_path, frequency=50000)
+        
+        self.manager = manager
+        self.devices = []
+        
+        # I2C config format is just a dict of addresses -> devices
+        for address, devices in config.items():
+            address = int(address, 0)
+            
+            for device, subconfig in devices.items():
+                try:
+                    self.devices.append(self.DEVICE_DRIVERS[device](address = address, i2c_driver = self, config = subconfig))
+                except Exception as e:
+                    logger.error(f"failed to initialize {device}@0x{address:2x} on {ftdi_path}: {e.__class__.__name__}: {e}")
+    
+    def disconnect(self):
+        logger.info("shutting down I2C")
+        for d in self.devices:
+            d.disconnect()
+        self.i2c.close()
+
+class Sht41Driver():
+    CMD_SERIAL_NUMBER = 0x89
+    CMD_MEASURE_HIGH_PRECISION = 0xFD
+
+    def __init__(self, address, i2c_driver, config):
+        self.sht41 = i2c_driver.i2c.get_port(address)
+
+        self.sht41.write((self.CMD_SERIAL_NUMBER, ))
+        sn = self.sht41.read(readlen = 6)
+        self.sn = binascii.hexlify(sn[0:2] + sn[3:5]).decode()
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', None)
+        
+        self.task = asyncio.create_task(self._task())
+        logger.info(f"probed SHT41 sensor at 0x{address:2x} with serial number {self.sn}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+    async def _task(self):
+        while True:
+            self.sht41.write((self.CMD_MEASURE_HIGH_PRECISION, ))
+            da = self.sht41.read(readlen = 6)
+            t_raw = int.from_bytes(da[0:2], "big")
+            rh_raw = int.from_bytes(da[3:5], "big")
+            
+            t_C = -45 + 175 * t_raw / 65535
+            rh_pct = -6 + 125 * rh_raw/65535
+            
+            # XXX: later, feed this to a x1plusd sensors subsystem that pubs to mqtt and to DBus
+            logger.info(f"SENSOR UPDATE: sensor name {self.name}, type sht41, serial {self.sn}, t {t_C}, rh_pct {rh_pct}")
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)
+    
+I2cDriver.DEVICE_DRIVERS['sht41'] = Sht41Driver

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -6,6 +6,7 @@ import binascii
 
 import usb.util
 import asyncio
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -59,17 +60,91 @@ class Sht41Driver():
     
     async def _task(self):
         while True:
-            self.sht41.write((self.CMD_MEASURE_HIGH_PRECISION, ))
-            da = self.sht41.read(readlen = 6)
-            t_raw = int.from_bytes(da[0:2], "big")
-            rh_raw = int.from_bytes(da[3:5], "big")
+            try:
+                self.sht41.write((self.CMD_MEASURE_HIGH_PRECISION, ))
+                da = self.sht41.read(readlen = 6)
+                t_raw = int.from_bytes(da[0:2], "big")
+                rh_raw = int.from_bytes(da[3:5], "big")
             
-            t_C = -45 + 175 * t_raw / 65535
-            rh_pct = -6 + 125 * rh_raw/65535
+                t_C = -45 + 175 * t_raw / 65535
+                rh_pct = -6 + 125 * rh_raw/65535
             
-            # XXX: later, feed this to a x1plusd sensors subsystem that pubs to mqtt and to DBus
-            logger.info(f"SENSOR UPDATE: sensor name {self.name}, type sht41, serial {self.sn}, t {t_C}, rh_pct {rh_pct}")
+                # XXX: later, feed this to a x1plusd sensors subsystem that pubs to mqtt and to DBus
+                logger.info(f"SENSOR UPDATE: sensor name {self.name}, type sht41, serial {self.sn}, t {t_C}, rh_pct {rh_pct}")
+            except Exception as e:
+                logger.info(f"SENSOR UPDATE: sensor name {self.name}, type sht41, serial {self.sn}, inop: exception {e.__class__.__name__}: {e}")
             
             await asyncio.sleep(self.interval_ms / 1000.0)
     
 I2cDriver.DEVICE_DRIVERS['sht41'] = Sht41Driver
+
+class Aht20Driver():
+    CMD_RESET = 0xBA
+    CMD_INITIALIZE = 0xE1
+    CMD_MEASURE = 0xAC
+
+    def __init__(self, address, i2c_driver, config):
+        self.aht20 = i2c_driver.i2c.get_port(address)
+
+        self.aht20.write((self.CMD_RESET, ))
+        time.sleep(0.05)
+        
+        self.aht20.write(b'\xE1\x08\x00')
+        time.sleep(0.02)
+        self.aht20.write(b'\xBE\x08\x00')
+
+        did_init = False
+        for i in range(10):
+            time.sleep(0.02)
+            rv = self.aht20.read(readlen = 1)
+            if (rv[0] & 0x88) == 0x08:
+                did_init = True
+                break
+        if not did_init:
+            raise Exception("AHT20 never calibrated")
+        
+        self.aht20.write(b'\x71')
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', None)
+        
+        self.task = asyncio.create_task(self._task())
+        logger.info(f"probed AHT20 sensor at 0x{address:2x}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+    async def _task(self):
+        while True:
+            try:
+                self.aht20.write(b'\xAC\x33\x00')#(self.CMD_MEASURE, 0x33, 0x00, ))
+                await asyncio.sleep(0.01)
+                
+                did_read = False
+                for i in range(10):
+                    da = self.aht20.read(readlen = 1)
+                    if da[0] & 0x80 == 0:
+                        did_read = True
+                        break
+                    await asyncio.sleep(0.01)
+                if not did_read:
+                    raise Exception("AHT20 did not finish measuring")
+
+                da = self.aht20.read(readlen = 6)
+                
+                rh_raw = (da[1] << 12) | (da[2] << 4) | (da[3] >> 4)
+                rh_pct = (rh_raw * 100) / 0x100000
+                
+                t_raw = ((da[3] & 0xF) << 16) | (da[4] << 8) | da[5]
+                t_C = ((t_raw * 200.0) / 0x100000) - 50                
+
+                # XXX: later, feed this to a x1plusd sensors subsystem that pubs to mqtt and to DBus
+                logger.info(f"SENSOR UPDATE: sensor name {self.name}, type aht20, serial None, t {t_C}, rh_pct {rh_pct}, da {da}")
+            except Exception as e:
+                logger.info(f"SENSOR UPDATE: sensor name {self.name}, type aht20, serial None, inop: exception {e.__class__.__name__}: {e}")
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)
+    
+I2cDriver.DEVICE_DRIVERS['aht20'] = Aht20Driver

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -13,13 +13,13 @@ logger = logging.getLogger(__name__)
 class I2cDriver():
     DEVICE_DRIVERS = {}
     
-    def __init__(self, manager, config, ftdi_path):
+    def __init__(self, daemon, config, ftdi_path):
         self.ftdi_path = ftdi_path
 
         self.i2c = pyftdi.i2c.I2cController()
         self.i2c.configure(ftdi_path, frequency=50000)
         
-        self.manager = manager
+        self.daemon = daemon
         self.devices = []
         
         # I2C config format is just a dict of addresses -> devices
@@ -43,7 +43,7 @@ class Sht41Driver():
     CMD_MEASURE_HIGH_PRECISION = 0xFD
 
     def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.manager.x1psensors
+        self.sensors = i2c_driver.daemon.sensors
 
         self.sht41 = i2c_driver.i2c.get_port(address)
 
@@ -87,7 +87,7 @@ class Aht20Driver():
     CMD_MEASURE = 0xAC
 
     def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.manager.x1psensors
+        self.sensors = i2c_driver.daemon.sensors
 
         self.aht20 = i2c_driver.i2c.get_port(address)
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -1,0 +1,61 @@
+import os
+import logging
+import asyncio
+
+from collections import namedtuple
+
+import pyftdi.spi
+
+logger = logging.getLogger(__name__)
+
+LedType = namedtuple('LedType', [ 'frequency', 'zero', 'one' ])
+
+LED_TYPES = {
+    'ws2812b': LedType(frequency = 6400000, zero = bytearray([0b11000000]), one = bytearray([0b11111100]))
+}
+
+class LedStripDriver():
+    def __init__(self, daemon, config, ftdi_path):
+        self.ftdi_path = ftdi_path
+        self.config = config
+
+        self.led = LED_TYPES[self.config.get('led_type', 'ws2812b')]
+        self.n_leds = int(self.config['leds'])
+        
+        self.spi = pyftdi.spi.SpiController()
+        self.spi.configure(ftdi_path, frequency = self.led.frequency)
+
+        self.lut = {}
+        for i in range(256):
+            v = bytearray()
+            for j in range(7, -1, -1):
+                if ((i >> j) & 1) == 0:
+                    v += self.led.zero
+                else:
+                    v += self.led.one
+            self.lut[i] = v
+        
+        self.put(b'\x00\x00\x00' * self.n_leds)
+        
+        self.anim = asyncio.create_task(self.led_anim())
+
+    def put(self, bs):
+        obs = bytearray(b'').join([self.lut[b] for b in bs])
+        self.spi.exchange(self.led.frequency, obs, readlen=0)
+    
+    def disconnect(self):
+        self.anim.cancel()
+        self.spi.close()
+    
+    async def led_anim(self):
+        import colorsys
+        ph = 0
+        while True:
+            ph = ph + 0.01
+            arr = []
+            for i in range(self.n_leds):
+                arr += colorsys.hsv_to_rgb((ph + i * 0.05) % 1, 1.0, 1.0)
+            self.put([int(a * 0.8 * 255) for a in arr])
+            if ph > 1:
+                ph -= 1
+            await asyncio.sleep(0.05)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import asyncio
+import time
 
 from collections import namedtuple
 
@@ -15,7 +16,11 @@ LED_TYPES = {
 }
 
 class LedStripDriver():
+    ANIMATIONS = {}
+    DEFAULT_ANIMATIONS = [ 'finish', 'paused', 'failed', 'rainbow' ]
+
     def __init__(self, daemon, config, ftdi_path):
+        self.daemon = daemon
         self.ftdi_path = ftdi_path
         self.config = config
 
@@ -35,17 +40,60 @@ class LedStripDriver():
                     v += self.led.one
             self.lut[i] = v
         
-        self.put(b'\x00\x00\x00' * self.n_leds)
+        self.put(b'\x00\x00\x00' * 128) # clear out a long strip
         
-        self.anim = asyncio.create_task(self.led_anim())
+        self.anim_task = None
+        self.curanim = None
 
+        # the 'animations' key is a list that looks like:
+        #
+        #   [ 'paused', { 'rainbow': { 'brightness': 0.5 } } ]
+        self.anim_list = []
+        for anim in self.config.get('animations', self.DEFAULT_ANIMATIONS):
+            if type(anim) == str:
+                self.anim_list.append(self.ANIMATIONS[anim](self, {}))
+                continue
+            elif type(anim) != dict or len(anim) != 1:
+                raise ValueError("animation must be either string or dictionary with exactly one key")
+            
+            (animname, subconfig) = next(iter(anim.items()))
+            self.anim_list.append(self.ANIMATIONS[animname](self, subconfig))
+
+        self.anim_watcher = asyncio.create_task(self.anim_watcher_task())
+            
     def put(self, bs):
         obs = bytearray(b'').join([self.lut[b] for b in bs])
         self.spi.exchange(self.led.frequency, obs, readlen=0)
     
     def disconnect(self):
-        self.anim.cancel()
+        if self.anim_task:
+            self.anim_task.cancel()
+            self.anim_task = None
+        self.anim_watcher.cancel()
         self.spi.close()
+    
+    async def anim_watcher_task(self):
+        with self.daemon.mqtt.report_messages() as report_queue:
+            while True:
+                msg = await report_queue.get()
+                # we do not do anything with it, we just use this to
+                # determine if the animation needs to be changed
+
+                wantanim = None
+                for anim in self.anim_list:
+                    if anim.can_render():
+                        wantanim = anim
+                        break
+                if wantanim != self.curanim:
+                    logger.debug(f"switching to animation {wantanim} from {self.curanim}")
+                    if self.anim_task:
+                        self.anim_task.cancel()
+                        self.anim_task = None
+                    self.curanim = wantanim
+                    if not wantanim:
+                        self.put(b'\x00\x00\x00' * self.n_leds)
+                    else:
+                        self.anim_task = asyncio.create_task(anim.task())
     
     async def led_anim(self):
         import colorsys
@@ -59,3 +107,117 @@ class LedStripDriver():
             if ph > 1:
                 ph -= 1
             await asyncio.sleep(0.05)
+
+###############
+
+import colorsys
+import math
+
+class RainbowAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.3)
+    
+    def can_render(self):
+        return True 
+    
+    async def task(self):
+        ph = 0
+        while True:
+            ph = ph + 0.01
+            arr = []
+            for i in range(self.leds.n_leds):
+                arr += colorsys.hsv_to_rgb((ph + i * 0.05) % 1, 1.0, 1.0)
+            self.leds.put([int(a * self.brightness * 255) for a in arr])
+            if ph > 1:
+                ph -= 1
+            await asyncio.sleep(0.05)
+        
+LedStripDriver.ANIMATIONS['rainbow'] = RainbowAnimation
+
+
+class PausedAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.25)
+    
+    def can_render(self):
+        return self.leds.daemon.mqtt.latest_print_status.get('gcode_state', None) == 'PAUSED'
+    
+    async def task(self):
+        BLINK_PATTERN = [(160, 250), (140, 700), (160, 250), (140, 700), (160, 250), (140, 3000)]
+        while True:
+            for on,off in BLINK_PATTERN:
+                arr = []
+                for i in range(self.leds.n_leds):
+                    arr += (self.brightness * 0.7, self.brightness * 1.0, 0.0,)
+                self.leds.put([int(a * 255) for a in arr])
+                await asyncio.sleep(on / 1000.0)
+                
+                self.leds.put(b'\x00\x00\x00' * self.leds.n_leds)
+                await asyncio.sleep(off / 1000.0)
+        
+LedStripDriver.ANIMATIONS['paused'] = PausedAnimation
+
+
+class FailedAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.25)
+        self.timeout = config.get('timeout', 120) # failure goes away after 2 minutes
+        self.last_failed_trn = 0
+        self.last_was_failed = False
+    
+    def can_render(self):
+        failed = self.leds.daemon.mqtt.latest_print_status.get('gcode_state', None) == 'FAILED'
+        if not self.last_was_failed and failed:
+            self.last_failed_trn = time.time()
+        self.last_was_failed = failed
+        return failed and (time.time() - self.last_failed_trn) < self.timeout
+    
+    async def task(self):
+        BLINK_PATTERN = [(750, 350), (750, 350), (750, 3000)]
+        while True:
+            for on,off in BLINK_PATTERN:
+                arr = []
+                for i in range(self.leds.n_leds):
+                    arr += (0.0, self.brightness * 1.0, 0.0,)
+                self.leds.put([int(a * 255) for a in arr])
+                await asyncio.sleep(on / 1000.0)
+                
+                arr = []
+                for i in range(self.leds.n_leds):
+                    arr += (0.0, 1/255, 0.0,)
+                self.leds.put([int(a * 255) for a in arr])
+                await asyncio.sleep(off / 1000.0)
+        
+LedStripDriver.ANIMATIONS['failed'] = FailedAnimation
+
+
+class FinishAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.4)
+        self.timeout = config.get('timeout', 600) # success goes away after 10 minutes
+        self.last_finish_trn = 0
+        self.last_was_finish = False
+    
+    def can_render(self):
+        finish = self.leds.daemon.mqtt.latest_print_status.get('gcode_state', None) == 'FINISH'
+        if not self.last_was_finish and finish:
+            self.last_finish_trn = time.time()
+        self.last_was_finish = finish
+        return finish and (time.time() - self.last_finish_trn) < self.timeout
+    
+    async def task(self):
+        ph = 0
+
+        while True:
+            ph += 0.05
+            br = 0.6 + math.sin(ph) * 0.4
+            self.leds.put([int(255 * br * self.brightness), 0, 0] * self.leds.n_leds)
+            await asyncio.sleep(0.05)
+        
+LedStripDriver.ANIMATIONS['finish'] = FinishAnimation
+
+

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
@@ -58,7 +58,7 @@ def _detect_x1p_002_b01():
 class ExpansionManager():
     DRIVERS = { 'i2c': I2cDriver }
 
-    def __init__(self, settings, **kwargs):
+    def __init__(self, settings, sensors, **kwargs):
         # We only have to look for an expansion board on boot, since it
         # can't be hot-installed.
         self.expansion = _detect_x1p_002_b01()
@@ -81,6 +81,7 @@ class ExpansionManager():
         self.x1psettings = settings
         for port in range(self.ftdi_nports):
             self.x1psettings.on(f"expansion.port_{chr(0x61 + port)}", lambda: self._update_drivers())
+        self.x1psensors = sensors
 
         self.last_configs = {}
         self.drivers = {}

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
@@ -10,6 +10,7 @@ import pyftdi.ftdi
 from ..dbus import *
 
 from .i2c import I2cDriver
+from .ledstrip import LedStripDriver
 from .detect_eeprom import detect_eeprom
 
 # workaround for missing ldconfig
@@ -62,7 +63,7 @@ EXPANSION_INTERFACE = "x1plus.expansion"
 EXPANSION_PATH = "/x1plus/expansion"
 
 class ExpansionManager(X1PlusDBusService):
-    DRIVERS = { 'i2c': I2cDriver }
+    DRIVERS = { 'i2c': I2cDriver, 'ledstrip': LedStripDriver }
 
     def __init__(self, daemon, **kwargs):
         self.daemon = daemon

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -11,12 +11,12 @@ import x1plus.utils
 logger = logging.getLogger(__name__)
 
 class MQTTClient():
-    def __init__(self, settings, **kwargs):
-        self.x1psettings = settings
+    def __init__(self, daemon, **kwargs):
+        self.daemon = daemon
         
-        self.x1psettings.on("mqtt.override.host", lambda: self._trigger_reconnect())
-        self.x1psettings.on("mqtt.override.password", lambda: self._trigger_reconnect())
-        self.x1psettings.on("mqtt.override.sn", lambda: self._trigger_reconnect())
+        self.daemon.settings.on("mqtt.override.host", lambda: self._trigger_reconnect())
+        self.daemon.settings.on("mqtt.override.password", lambda: self._trigger_reconnect())
+        self.daemon.settings.on("mqtt.override.sn", lambda: self._trigger_reconnect())
         
         self.mqttc = None
         self.reconnect_event = asyncio.Event()
@@ -51,9 +51,9 @@ class MQTTClient():
                 password = None
                 if os.path.isfile("/config/device/access_token"):
                     password = open("/config/device/access_token", "r").read()
-                password = self.x1psettings.get("mqtt.override.password", password)
+                password = self.daemon.settings.get("mqtt.override.password", password)
                 
-                self.sn = self.x1psettings.get("mqtt.override.sn", None)
+                self.sn = self.daemon.settings.get("mqtt.override.sn", None)
                 if not self.sn:
                     sn = x1plus.utils.serial_number()
                 
@@ -62,7 +62,7 @@ class MQTTClient():
                 ssl_ctx.verify_mode = ssl.CERT_NONE
 
                 client = aiomqtt.Client(
-                    hostname = self.x1psettings.get("mqtt.override.host", "127.0.0.1"),
+                    hostname = self.daemon.settings.get("mqtt.override.host", "127.0.0.1"),
                     port = 8883,
                     username = "bblp",
                     password = password,

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -74,7 +74,7 @@ class MQTTClient():
                     await client.subscribe("device/+/report")
                     self.mqttc = client
                     loop_task = asyncio.create_task(self.mqtt_message_loop())
-                    await asyncio.wait([loop_task, self.reconnect_event.wait()], return_when=asyncio.FIRST_COMPLETED)
+                    await asyncio.wait([loop_task, asyncio.ensure_future(self.reconnect_event.wait())], return_when=asyncio.FIRST_COMPLETED)
                     loop_task.cancel()
                     try:
                         await loop_task

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -40,7 +40,7 @@ class MQTTClient():
                 for handler in self.request_message_handlers.copy(): # avoid problems if this gets mutated out from under us mid handler
                     await handler(payload)
             elif "/report" in message.topic.value:
-                if 'print' in payload:
+                if 'print' in payload and payload['print'].get('command', None) == "push_status":
                     self.latest_print_status = payload['print']
                 for handler in self.report_message_handlers.copy(): # avoid problems if this gets mutated out from under us mid handler
                     await handler(payload)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -23,6 +23,8 @@ class MQTTClient():
         
         self.request_message_handlers = set()
         self.report_message_handlers = set()
+        
+        self.latest_print_status = {}
     
     def _trigger_reconnect(self):
         self.reconnect_event.set()
@@ -38,6 +40,8 @@ class MQTTClient():
                 for handler in self.request_message_handlers.copy(): # avoid problems if this gets mutated out from under us mid handler
                     await handler(payload)
             elif "/report" in message.topic.value:
+                if 'print' in payload:
+                    self.latest_print_status = payload['print']
                 for handler in self.report_message_handlers.copy(): # avoid problems if this gets mutated out from under us mid handler
                     await handler(payload)
             else:

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class PolarPrintService:
-    def __init__(self, settings):
+    def __init__(self, daemon):
+        self.daemon = daemon
         self.polar_sn = 0
         # Todo: VERY IMPORTANT!! The public and private keys MUST be moved to
         # non-volatile memory before release.
@@ -30,9 +31,8 @@ class PolarPrintService:
         self.socket = None
         # self.ip = ""
         # Todo: Fix two "on" fn calls below. Also, start communicating with dbus.
-        self.polar_settings = settings
-        # self.polar_settings.on("polarprint.enabled", self.sync_startstop())
-        # self.polar_settings.on("self.pin", self.set_pin())
+        # self.daemon.settings.on("polarprint.enabled", self.sync_startstop())
+        # self.daemon.settings.on("self.pin", self.set_pin())
         self.socket = None
         self.connected = False  # We might not need this, but here for now.
 
@@ -242,7 +242,7 @@ class PolarPrintService:
         from card. The current print should finish. Disconnect socket so that
         username and PIN don't keep being requested and printer doesn't reregister.
         """
-        if response["serialNumber"] == self.polar_settings.get("polar.sn"):
+        if response["serialNumber"] == self.daemon.settings.get("polar.sn"):
             self.sn = ""
             self.username = ""
             self.public_key = ""
@@ -277,7 +277,7 @@ class PolarPrintService:
             if not self.pin:
                 # Get it from the interface.
                 pass
-            if not self.polar_settings.get("polar.username", ""):
+            if not self.daemon.settings.get("polar.username", ""):
                 # Get it from the interface.
                 pass
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
@@ -1,0 +1,37 @@
+import logging
+import asyncio
+import time
+
+import x1plus.utils
+from .dbus import *
+
+logger = logging.getLogger(__name__)
+
+SENSORS_INTERFACE = "x1plus.sensors"
+SENSORS_PATH = "/x1plus/sensors"
+SENSOR_TIMEOUT = 60
+
+class SensorsService(X1PlusDBusService):
+    def __init__(self, settings, **kwargs):
+        self.x1psettings = settings
+        self.sensors = {}
+        super().__init__(
+            dbus_interface=SENSORS_INTERFACE, dbus_path=SENSORS_PATH, **kwargs
+        )
+
+    async def dbus_GetSensors(self, arg):
+        now = time.time()
+        for name in list(self.sensors.keys()):
+            if (now - self.sensors[name]['timestamp']) > SENSOR_TIMEOUT:
+                logger.info(f"sensor {name} has not been heard from in quite a while; removing it")
+                del self.sensors[name]
+        return self.sensors
+    
+    async def publish(self, name, **data):
+        data['timestamp'] = time.time()
+        if name not in self.sensors:
+            logger.info(f"sensor {name} has come online with data {data}")
+        self.sensors[name] = data
+
+        await self.emit_signal("SensorUpdate", { name: data })
+        # XXX: publish to MQTT also, at some point

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
@@ -12,8 +12,8 @@ SENSORS_PATH = "/x1plus/sensors"
 SENSOR_TIMEOUT = 60
 
 class SensorsService(X1PlusDBusService):
-    def __init__(self, settings, **kwargs):
-        self.x1psettings = settings
+    def __init__(self, daemon, **kwargs):
+        self.daemon = daemon
         self.sensors = {}
         super().__init__(
             dbus_interface=SENSORS_INTERFACE, dbus_path=SENSORS_PATH, **kwargs


### PR DESCRIPTION
The [X1Plus Expansion Board](https://github.com/jwise/x1-expander) is a platform for X1 that allows external hardware features.  The initial revision, X1P-002-B01, has support for the following:

* An Ethernet port, provided by LAN9514.
* A small EEPROM with board identity.
* Up to four expansion ports (two ports on current builds with FT2232) for addin modules like X1P-004 and X1P-005.
* Two USB ports.
* An Adafruit / Sparkfun-compatible I2C connector.

We add support in x1plusd to detect the board's EEPROM, to detect addin module EEPROMs, and to support some I2C peripherals and an addin module.  To do that, we add the following:

* `x1plusd.expansion.manager` is added as scaffolding to respond to DBus requests to query the expansion state, and to probe the expansion board on boot.  Additionally, the expansion manager reacts to x1plusd.settings changes that specify what is attached to each port of the FTDI.
* We introduce drivers, `x1plusd.expansion.i2c` and `x1plusd.expansion.ledstrip`, that implement support for two different types of I2C thermometers (SHT41 and AHT20), and a few different animations on a WS2812B LED strip.
* We add an initial `x1plusd.sensors` manager -- for now, only holding values from I2C sensors, but in the future, it will also hold internal printer sensors.
* We make a small change to `x1plusd` to pass around a single `X1PlusDaemon` object, rather than each of the subobjects -- this makes it more possible to reach the MQTT subsystem from the sensors subsystem, or the sensors subsystem from the expansion subsystem.

To interface with this, consider settings of the following form:

```
[root@BL-P001-sdcard:~]# x1plus settings get
expansion.port_a: {"ledstrip": {"leds": 10}}
expansion.port_b: {"i2c": {"0x44": {"sht41": {"name": "room"}}}}
```