### PR TITLE
x1plusd.expansion: add GPIO output controls

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -34,7 +34,7 @@ class X1PlusDaemon:
         self.gpios = GpioManager(daemon=self)
         self.expansion = ExpansionManager(router=self.router, daemon=self)
         self.mcproto = MCProtoParser(daemon=self)
-        self.actions = ActionHandler(daemon=self)
+        self.actions = ActionHandler(router=self.router, daemon=self)
         if not self.settings.get("polar_cloud", False):
             self.polar_cloud = None
         else:
@@ -51,6 +51,7 @@ class X1PlusDaemon:
         asyncio.create_task(self.sensors.task())
         asyncio.create_task(self.expansion.task())
         asyncio.create_task(self.mcproto.task())
+        asyncio.create_task(self.actions.task())
         if self.polar_cloud:
             asyncio.create_task(self.polar_cloud.begin())
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -13,6 +13,7 @@ from .expansion import ExpansionManager
 from .sensors import SensorsService
 from .mcproto import MCProtoParser
 from .actions import ActionHandler
+from .gpios import GpioManager
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ class X1PlusDaemon:
         self.ssh = SSHService(daemon=self)
         self.httpd = HTTPService(router=self.router, daemon=self)
         self.sensors = SensorsService(router=self.router, daemon=self)
+        self.gpios = GpioManager(daemon=self)
         self.expansion = ExpansionManager(router=self.router, daemon=self)
         self.mcproto = MCProtoParser(daemon=self)
         self.actions = ActionHandler(daemon=self)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
@@ -102,5 +102,5 @@ async def _action_gcode(handler, subconfig):
 async def _action_delay(handler, subconfig):
     logger.debug(f"delay action: {subconfig}")
     if type(subconfig) != int and type(subconfig) != float:
-        raise TypeError(f"delay parameter {subconfig} was not str")
+        raise TypeError(f"delay parameter {subconfig} was not numberish")
     await asyncio.sleep(subconfig)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
@@ -38,13 +38,29 @@ them to JSON before embedding them in G-code.
 import asyncio
 import logging
 
+from .dbus import *
+
 logger = logging.getLogger(__name__)
 
 _registered_actions = {}
 
-class ActionHandler():
-    def __init__(self, daemon):
+ACTIONS_INTERFACE = "x1plus.actions"
+ACTIONS_PATH = "/x1plus/actions"
+
+class ActionHandler(X1PlusDBusService):
+    def __init__(self, daemon, **kwargs):
         self.daemon = daemon
+        super().__init__(
+            dbus_interface=ACTIONS_INTERFACE, dbus_path=ACTIONS_PATH, **kwargs
+        )
+
+    async def dbus_Execute(self, req):
+        async def subtask():
+            logger.info("starting ExecuteAction from dbus")
+            await self.execute(req)
+            logger.info("action execution complete")
+        asyncio.create_task(subtask())
+        return None
     
     # actionobj is a parsed json object.  execute is cancellable!
     async def execute_step(self, actionobj):

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/gpios.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/gpios.py
@@ -1,0 +1,109 @@
+from abc import ABC, abstractmethod
+
+class Gpio(ABC):
+    @property
+    @abstractmethod
+    def attributes(self):
+        pass
+    
+    @abstractmethod
+    def output(self, on):
+        pass
+    
+    @abstractmethod
+    def tristate(self):
+        pass
+    
+    @abstractmethod
+    def read(self):
+        pass
+
+class GpioManager:
+    """
+    Abstraction for expansion board (and other) GPIOs.
+
+    The GpioManager holds an abstraction to GPIOs that can be outputs or
+    inputs.  Because GPIOs sometimes are shared with other FTDI ports (or
+    might even be expanded on I2C GPIO expanders?), they are provided
+    through individual drivers that register them and actually operate on
+    them (this is implemented by an instance of a "class Gpio", which
+    presumably has to reach into a parent object to change some state on the
+    FTDI port).
+    
+    GPIOs are specified in a dictionary of attributes, and you can look up
+    GPIOs as combinations of these.  For instance, a GPIO might have a
+    function ("shutter", "buzzer"; "button"); it might have a board that it
+    is part of ("X1P-004"); it might have a location ("left", "right"); it
+    has a pin number (0, 1, 2); and it has a port ("a", "b", "c", "d"). 
+    Putting it together, the button on an Andon board has the following
+    attributes:
+    
+      {
+        "function": "button",
+        "position": "left",
+        "board_type": "X1P-005",
+        "board_serial": "X1P-005-A02-0143"
+        "pin": 6,
+        "port": "a",
+      }
+    
+    Setting or resetting a GPIO acts on all specified ports at the same
+    time; for instance, you may wish to turn on all GPIOs that function as
+    camera shutters, or you may wish to refine this further to turn on only
+    the camera shutters on pin 0 or port A.  However, ports must be uniquely
+    specified in order to query them.
+    
+    Some GPIOs may have their functionality inverted (for instance, some
+    buzzers may be active-low).  This is expected to be handled by the
+    "class Gpio", if specified in the driver's GPIO configuration.
+    """
+
+    def __init__(self):
+        self.gpios = set()
+    
+    def find(self, **kwargs):
+        return set(filter(lambda gpio: all(hasattr(gpio, k) and getattr(gpio, k) == v for k,v in items(kwargs)), self.gpios))
+    
+    def port_properties(self, port):
+        # XXX
+        return {
+            "port": "a",
+            "board_type": "X1P-005",
+            "board_serial": "X1P-005-A02-0123",
+        }
+
+    def register(self, gpio):
+        assert len(self.find(**gpio.attributes)) == 0
+        assert gpio not in self.gpios
+        self.gpios.add(gpio)
+    
+    def unregister(self, gpio):
+        self.gpios.remove(gpio) # asserts if not registered
+    
+    # convenience wrappers around find and output/tristate/read
+    def output(self, on, **kwargs):
+        gpios = self.find(**kwargs)
+        if len(gpios) == 0:
+            raise KeyError
+        for g in gpios:
+            g.output(on)
+    
+    def tristate(self, **kwargs):
+        gpios = self.find(**kwargs)
+        if len(gpios) == 0:
+            raise KeyError
+        for g in gpios:
+            g.tristate()
+    
+    def read(self, **kwargs):
+        gpios = self.find(**kwargs)
+        if len(gpios) != 1:
+            raise KeyError
+        return gpios.pop().read()
+        
+    # convenience wrappers around output
+    def on(self, **kwargs):
+        self.output(on = True, **kwargs)
+
+    def off(self, **kwargs):
+        self.output(on = False, **kwargs)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class I2cDriver():
     DEVICE_DRIVERS = {}
     
-    def __init__(self, daemon, config, ftdi_path):
+    def __init__(self, daemon, config, ftdi_path, port_name):
         self.ftdi_path = ftdi_path
 
         self.i2c = pyftdi.i2c.I2cController()

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -37,10 +37,15 @@ class LedStripDriver():
         self.gpio_dir = 0x03
         self.gpio_out = 0
         
-        # XXX: error check this
         self.gpio_instances = []
-        # XXX: type check this
+        gpios = self.config.get('gpios', [])
+        if type(gpios) != list:
+            raise TypeError("gpios config item was not a list")
         for gpio_def in self.config.get('gpios', []):
+            if type(gpio_def) != dict:
+                raise TypeError("gpio configuration item was not an object")
+            if 'pin' not in gpio_def or type(gpio_def['pin']) != int:
+                raise TypeError("gpio configuration item did not have a pin defined, or pin was not an int")
             gpio_def = { **self.daemon.gpios.port_properties(port_name), **gpio_def }
             inst = LedStripGpio(self, 1 << gpio_def['pin'], gpio_def)
             self.daemon.gpios.register(inst)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -22,7 +22,7 @@ class LedStripDriver():
     ANIMATIONS = {}
     DEFAULT_ANIMATIONS = [ 'running', 'finish', 'paused', 'failed', 'rainbow' ]
 
-    def __init__(self, daemon, config, ftdi_path):
+    def __init__(self, daemon, config, ftdi_path, port_name):
         self.daemon = daemon
         self.ftdi_path = ftdi_path
         self.config = config
@@ -41,7 +41,7 @@ class LedStripDriver():
         self.gpio_instances = []
         # XXX: type check this
         for gpio_def in self.config.get('gpios', []):
-            # XXX: add port information to GPIO definition
+            gpio_def = { **self.daemon.gpios.port_properties(port_name), **gpio_def }
             inst = LedStripGpio(self, 1 << gpio_def['pin'], gpio_def)
             self.daemon.gpios.register(inst)
             self.gpio_instances.append(inst)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
@@ -185,12 +185,3 @@ class ExpansionManager(X1PlusDBusService):
                 'serial': eeprom['serial'],
             } if eeprom else None for port_name, eeprom in self.eeproms.items() },
         }
-    
-    # XXX: probably should go in actions later
-    async def dbus_ExecuteAction(self, req):
-        async def subtask():
-            logger.info("starting ExecuteAction from dbus")
-            await self.daemon.actions.execute(req)
-            logger.info("action execution complete")
-        asyncio.create_task(subtask())
-        return None

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
@@ -1,10 +1,10 @@
+import asyncio
+from collections import namedtuple
 import os
 import logging
-
-from collections import namedtuple
-import usb
 import time
 
+import usb
 import pyftdi.ftdi
 
 from ..dbus import *
@@ -182,3 +182,12 @@ class ExpansionManager(X1PlusDBusService):
                 'serial': eeprom['serial'],
             } if eeprom else None for port_name, eeprom in self.eeproms.items() },
         }
+    
+    # XXX: probably should go in actions later
+    async def dbus_ExecuteAction(self, req):
+        async def subtask():
+            logger.info("starting ExecuteAction from dbus")
+            await self.daemon.actions.execute(req)
+            logger.info("action execution complete")
+        asyncio.create_task(subtask())
+        return None

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import asyncio
 import logging
 
 from . import actions

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
@@ -97,12 +97,16 @@ class GpioManager:
     def find(self, **kwargs):
         return set(filter(lambda gpio: all(k in gpio.attributes and gpio.attributes[k] == v for k,v in kwargs.items()), self.gpios))
     
-    def port_properties(self, port):
-        # XXX
+    def port_properties(self, port_name):
+        if port_name not in self.daemon.expansion.eeproms:
+            return {
+                "port": "unknown"
+            }
+
         return {
-            "port": "a",
-            "board_type": "X1P-005",
-            "board_serial": "X1P-005-A02-0123",
+            "port": port_name.split('_')[-1],
+            "board_type": self.daemon.expansion.eeproms[port_name]['model'],
+            "board_serial": '-'.join(self.daemon.expansion.eeproms[port_name][k] for k in ['model', 'revision', 'serial']),
         }
 
     def register(self, gpio):


### PR DESCRIPTION
In the X1Plus Expansion Board world, we suddenly grow the concept of external GPIOs.  (Some day soon, we will also have internal GPIOs -- the buttons on the top of the printer!)  The X1P-005 Andon Board has a GPIO output that one might wish to trigger from Gcode -- it has a beeper.  The X1P-006 Shutter Release Board also has two useful GPIOs that one might wish to use to, er, well, trigger camera shutter releases.

In this PR, we add a mechanism by which parts of the system can define GPIOs, and provide an abstraction layer to access them.  The two problems that we try to solve are that not all GPIOs are the same, and that GPIOs can have many semantic descriptors.  The first of those, indeed, is that not all GPIOs are created equal, even as FTDI GPIOs: GPIOs on a SPI-opened FTDI device behave differently from GPIOs on an I2C-opened FTDI device, which behave differently from GPIOs on a FTDI device that has no special function otherwise.  The GPIO API provides an abstract base class, `Gpio`, that a GPIO provider needs to override.

The second of these is that users may want to specify GPIOs in many different ways.  For instance, a user might want to trigger all camera shutters on the system at once, without caring which one they're after.  Or they might want to trigger both camera shutters on a single X1P-006, but not camera shutters on another X1P-006 in a different slot.  Or they might want to trigger a specific pin that doesn't have a functionality named for it.  The GPIO API solves this by naming GPIOs as dictionaries of attributes, and providing some implicit attributes for each port, as appropriate.  For instance, a user might wish to define an X1P-005 board as having a GPIO with dictionary `{"pin": 3, "function": "buzzer"}`, but the GPIO also gets additional implicit properties to describe the board and port it is attached to: `{'port': 'a', 'board_type': 'X1P-005', 'board_serial': 'X1P-005-B01-00000001', 'pin': 3, 'function': 'buzzer'}`

A user can select a GPIO by filtering by one or more of its attributes.  For instance, that GPIO could be selected as `{"port": "a", 'pin": 3}`; as `{"function": "buzzer"}`; or even as `{"board_serial": "X1P-005-B01-00000001"}`.

This PR defines an initial provider for GPIOs from the `ledstrip` expansion driver, but future work would be to have a raw `gpio` expansion driver -- and, of course, to have a provider for the input button GPIOs on the system, and the chamber and toolhead lights as output GPIOs.  This PR also defines a simple client for GPIOs as a `gpio` Action: `{"gpio": {"action": "pulse", "duration": 0.2, "gpio": { "function": "buzzer" }}}`.  This PR does not support GPIO input, but this would be useful in the future as well.

To test this, consider attaching an X1P-006-B01 to an expansion board, and setting the `expansion.port_a` setting to the value `{"ledstrip": {"leds": 9, "gpios": [{"pin": 3, "function": "buzzer"}]}}`.  Then, try Gcode of the form:

```
M400
;x1plus define 2 [{"gpio": {"action": "pulse", "duration": 0.2, "gpio": { "function": "buzzer" }}}, {"delay": 0.2}, {"gpio": {"action": "pulse", "duration": 0.2, "gpio": { "function": "buzzer" }}}, {"gcode": "M400 W0"}]
M73 P50 R0
M976 S99 P2 
M400 W1
```