### PR TITLE
Add SD card validation step to client-side installer

### DIFF
--- a/installer-clientside/README.md
+++ b/installer-clientside/README.md
@@ -1,13 +1,14 @@
 # Building the installer
 
-This is sort of a mess. Make sure to do things in exactly this order. Otherwise
-things will go wrong. If you understand Node release engineering I want to hear
-from you. Actually I don't, I just want a PR for it. Thanks. Make sure to build
-the docker image first.
+This is sort of a mess, but at least it's in a script now. If you understand
+Node release engineering I want to hear from you. Actually I don't, I just want
+a PR for it. Thanks.
 
-* ```docker run -u `id -u` -v `pwd`:/work x1plusbuild bash -c 'cd installer-clientside/x1p-js && npm i && npm run build'```
-* ```docker run -u `id -u` -v `pwd`:/work x1plusbuild bash -c 'make && ln -s "$(jq -r '.cfwVersion' ota.json).x1p" latest.x1p'```
-* ```docker run -u `id -u` -v `pwd`:/work x1plusbuild bash -c 'cd installer-clientside/install-gui && npm i && bash pack-em-all.sh'```
+Make sure the user running the following command is a member of the docker
+group. DO NOT USE `sudo`
+```./build.sh```
+
+The output files should then be found in `install-gui/out/`
 
 # Local MQTT test server
 

--- a/installer-clientside/README.md
+++ b/installer-clientside/README.md
@@ -1,13 +1,13 @@
 # Building the installer
 
-This is sort of a mess.  Make sure to do things in roughly exactly this
-order.  Otherwise things will go wrong.  If you understand Node release
-engineering I want to hear from you.  Actually I don't, I just want a PR for
-it.  Thanks.
+This is sort of a mess. Make sure to do things in exactly this order. Otherwise
+things will go wrong. If you understand Node release engineering I want to hear
+from you. Actually I don't, I just want a PR for it. Thanks. Make sure to build
+the docker image first.
 
-* `pushd x1p-js; npm i; npm run build; popd`
-* `pushd ../; make; ln -s ...whatever.../latest.x1p; popd`
-* `pushd install-gui; npm i; bash pack-em-all.sh; popd`
+* ```docker run -u `id -u` -v `pwd`:/work x1plusbuild bash -c 'cd installer-clientside/x1p-js && npm i && npm run build'```
+* ```docker run -u `id -u` -v `pwd`:/work x1plusbuild bash -c 'make && ln -s "$(jq -r '.cfwVersion' ota.json).x1p" latest.x1p'```
+* ```docker run -u `id -u` -v `pwd`:/work x1plusbuild bash -c 'cd installer-clientside/install-gui && npm i && bash pack-em-all.sh'```
 
 # Local MQTT test server
 

--- a/installer-clientside/build.sh
+++ b/installer-clientside/build.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+### THIS ONLY WORKS IF THE USER HAS BEEN ADDED TO THE DOCKER GROUP
+### RUNNING THIS WITH `sudo ./build.sh` RESULTS IN DUBIOUS OWNERSHIP
+### ERRORS WHEN BUILDING THE FIRMWARE
+
+cd ..
+# check if x1plusbuild docker image exists
+if ! docker image ls --format '{{.Repository}}' | grep -q '^x1plusbuild$'; then
+    echo "x1plusbuild docker image not found, building..."
+    docker build -t x1plusbuild scripts/docker/ || exit 1
+fi
+
+# build the installer
+echo "Building the electron app..."
+docker run -u "$(id -u)" -v "$(pwd)":/work x1plusbuild bash -c 'cd installer-clientside/x1p-js && npm i && npm run build' || exit 1
+
+# build the firmware
+echo "Building the latest firmware..."
+[ -L latest.x1p ] && rm latest.x1p # delete the symlink to the old firmware before building the new one
+docker run -u "$(id -u)" -v "$(pwd)":/work x1plusbuild bash -c 'make && ln -s "$(jq -r '.cfwVersion' ota.json).x1p" latest.x1p' || exit 1
+
+# package the installer with the latest build of the firmware
+echo "Packaging everything..."
+docker run -u "$(id -u)" -v "$(pwd)":/work x1plusbuild bash -c 'cd installer-clientside/install-gui && npm i && bash pack-em-all.sh' || exit 1
+
+cd installer-clientside || exit 1


### PR DESCRIPTION
This PR add a new step to the client-side installer. The new step does the following:

1. Checks the filesystem on the SD card to ensure it is already formatted as FAT32. If not, it stops the installation process and notifies the user.
2. Checks the available space on the SD card to ensure there is enough room to install X1+. The default install size is ~1.5Gb, so I set the check for >2GB to leave room to grow, and an easy way to modify that check in the code later on. If there is not enough room on the SD card, it stops the installation process and notifies the user.

This PR could be extended to implement #107, but if that is a no-go then that issue can be closed as rejected with the merge of this PR in its current state.

I have tested the new installer and confirmed that it's working.