### PR TITLE
x1plusd: GPIO input support

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -36,6 +36,8 @@ class LedStripDriver():
         
         self.gpio_dir = 0x03
         self.gpio_out = 0
+        self.gpio_last_read_time = 0
+        self.gpio_last_read_data = None
         
         self.gpio_instances = []
         gpios = self.config.get('gpios', [])
@@ -141,6 +143,11 @@ class LedStripDriver():
 ###############
 
 class LedStripGpio(Gpio):
+    # do not actually submit a read more frequently than this: use the
+    # cached result, if the system is polling multiple GPIOs in one polling
+    # cycle
+    READ_CACHE_INTERVAL_MS = 50
+
     def __init__(self, ledstrip, pin, attr):
         # pin: 1 << x
         self.ledstrip = ledstrip
@@ -168,11 +175,16 @@ class LedStripGpio(Gpio):
         self.ledstrip.update_gpio()
     
     def read(self):
-        # XXX: probably should cache reads some
-        self.ledstrip.ftdi.write_data(bytes([Ftdi.GET_BITS_LOW, Ftdi.SEND_IMMEDIATE]))
-        data = self.ledstrip.ftdi.read_data_bytes(1, 4)
-        if len(data) != 1:
-            raise IOError('FTDI did not read bytes back')
+        now = time.time()
+        if (now - self.ledstrip.gpio_last_read_time) < (self.READ_CACHE_INTERVAL_MS / 1000.0):
+            data = self.ledstrip.gpio_last_read_data
+        else:
+            self.ledstrip.ftdi.write_data(bytes([Ftdi.GET_BITS_LOW, Ftdi.SEND_IMMEDIATE]))
+            data = self.ledstrip.ftdi.read_data_bytes(1, 4)
+            if len(data) != 1:
+                raise IOError('FTDI did not read bytes back')
+            self.ledstrip.gpio_last_read_time = now
+            self.ledstrip.gpio_last_read_data = data
         inverted = self.attr.get('inverted', False)
         return ((data[0] & self.pin) == self.pin) ^ inverted
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -150,6 +150,10 @@ class LedStripGpio(Gpio):
     @property
     def attributes(self):
         return self.attr
+
+    @property
+    def polling(self):
+        return True
     
     def output(self, val):
         self.ledstrip.gpio_dir |= self.pin

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -168,11 +168,13 @@ class LedStripGpio(Gpio):
         self.ledstrip.update_gpio()
     
     def read(self):
+        # XXX: probably should cache reads some
         self.ledstrip.ftdi.write_data(bytes([Ftdi.GET_BITS_LOW, Ftdi.SEND_IMMEDIATE]))
         data = self.ledstrip.ftdi.read_data_bytes(1, 4)
         if len(data) != 1:
             raise IOError('FTDI did not read bytes back')
-        return (data[0] & self.pin) == self.pin
+        inverted = self.attr.get('inverted', False)
+        return ((data[0] & self.pin) == self.pin) ^ inverted
 
 ###############
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -153,6 +153,7 @@ class LedStripGpio(Gpio):
         self.ledstrip = ledstrip
         self.pin = pin
         self.attr = attr
+        super().__init__()
     
     @property
     def attributes(self):

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
@@ -70,6 +70,9 @@ class ExpansionManager(X1PlusDBusService):
 
         self.eeproms = {}
         self.drivers = {}
+        self.ftdi_nports = 0
+        self.ftdi_path = None
+        self.last_configs = {}
 
         # We only have to look for an expansion board on boot, since it
         # can't be hot-installed.
@@ -118,6 +121,9 @@ class ExpansionManager(X1PlusDBusService):
         await super().task()
     
     def _update_drivers(self):
+        if not self.expansion:
+            return
+
         # Workaround https://github.com/eblot/pyftdi/issues/261 by resetting
         # all drivers on the FTDI every time.
         did_change = False

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
@@ -99,9 +99,9 @@ class GpioManager:
         return set(filter(lambda gpio: all(k in gpio.attributes and gpio.attributes[k] == v for k,v in kwargs.items()), self.gpios))
     
     def port_properties(self, port_name):
-        if port_name not in self.daemon.expansion.eeproms:
+        if self.daemon.expansion.eeproms.get(port_name, None) is None:
             return {
-                "port": "unknown"
+                "port": port_name.split('_')[-1],
             }
 
         return {


### PR DESCRIPTION
Adds support in the `GpioManager` for various features that are necessary to take input from system GPIOs.  Specifically:

* Adds an `on_event` mechanism that can allow an internal x1plusd component to temporarily or permanently register a callback for any matching set of GPIOs, or to get a queue of events from the GPIO.
* Adds support for polling GPIOs from sources that do not support interrupts (like the FTDI).
* Implements the `gpio` action's `wait` command using a temporary `on_event` receiver that lasts for the life of the `gpio` action.
* Implements settings-backed GPIO actions.

You can try some of this with:
```
# x1plus settings set expansion.port_a --json '{"ledstrip": {"leds": 25, "gpios": [{"pin": 3, "function": "buzzer", "default": 0}, {"pin": 5, "default": 1}, {"pin": 6, "function": "button", "inverted": true}, {"pin": 7, "function": "button", "inverted": true}]}}'
# dbus-send --system --print-reply --dest=x1plus.x1plusd /x1plus/actions x1plus.actions.Execute string:'[{"gpio": {"action": "pulse", "gpio": {"function": "buzzer"}, "duration": 0.01}}, {"gpio": {"action": "wait", "gpio": {"function": "button", "pin": 6}, "value": true, "timeout": 5}}, {"gpio": {"action": "pulse", "gpio": {"function": "buzzer"}, "duration": 0.01}}]'
```
which configures the port to support an X1P-006, and triggers an action that makes the X1P-006 (or any other buzzers on the system) beep once, wait for the left button on the X1P-006 to be pressed (with a 5 second timeout), and then makes the X1P-006 beep again.

You can also try:
```
# x1plus settings set gpio.actions --json '[{"gpio": {"function": "button"}, "event": "rising", "action": {"gpio": {"action": "pulse", "gpio": {"function":  "buzzer"}, "duration": 0.01}}}]'
```
which causes all buzzers on the system to chirp any time any GPIO button on the system is pressed.

Finally, you can also differentiate long-presses from short-presses, with the following actions that can be used to jog the Z-axis using the buttons on an X1P-006:
```
# x1plus settings set gpio.actions --json '[{"gpio": {"board_type": "X1P-005", "pin": 6}, "event": "long_press", "action": {"gcode": "G91\nG0 Z7.5"}}, {"gpio": {"board_type": "X1P-005", "pin": 7}, "event": "long_press", "action": {"gcode": "G91\nG0 Z-7.5"}}, {"gpio": {"board_type": "X1P-005", "pin": 6}, "event": "short_press", "action": {"gcode": "G91\nG0 Z2.5"}}, {"gpio": {"board_type": "X1P-005", "pin": 7}, "event": "short_press", "action": {"gcode": "G91\nG0 Z-2.5"}}]'
```

The whole thing makes me think that we need a way to import JSON and YAML files rather than typing big blobs of JSON in on the command line.  But for now, here it is.

Fixes #369 and #368.