### PR TITLE
Migrate HardwarePage.qml settings

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/HardwarePage.qml
@@ -19,14 +19,10 @@ Rectangle {
     property var fan: [qsTr("Not installed"), qsTr("Installed")]
     color: Colors.gray_700
     property var maintain: DeviceManager.maintain
-    property var brightness: DeviceManager.getSetting("cfw_brightness", 100.0)
-    property var toolheadLED: DeviceManager.getSetting("cfw_toolhead_led", false)
+    property var brightness: X1Plus.Settings.get("lcd.brightness",100)
+    property var toolheadLED: X1Plus.Settings.get("leds.toolhead", false)
+    property var gcode: X1Plus.GcodeGenerator
 
-    Timer {
-        id: dispBrightnessChangeTimer
-        interval: 300; running: false; repeat: false
-        onTriggered: DeviceManager.putSetting("cfw_brightness", dispBrightnessAdj.value);
-    }
     Timer {
         id: myTime
         interval: 5000
@@ -413,7 +409,11 @@ Rectangle {
             onMoved: {
                 brightness = value;
                 X1PlusNative.updateBacklight(value);
-                dispBrightnessChangeTimer.restart();
+            }
+            onPressedChanged: {
+                if (!pressed) {
+                    X1Plus.Settings.put("lcd.brightness", brightness);
+                }
             }
             background: Rectangle {
                 anchors.centerIn: parent
@@ -446,11 +446,11 @@ Rectangle {
             id: toolheadLedButton
             anchors.verticalCenter: toolheadLedTxt.verticalCenter
             anchors.right: buttonGrid.right
-            dynamicChecked: DeviceManager.getSetting("cfw_toolhead_led", false)
+            dynamicChecked: X1Plus.Settings.get("leds.toolhead",false)
             onToggled: {
                 dynamicChecked = checked
-                DeviceManager.putSetting("cfw_toolhead_led", checked);
-                X1Plus.sendGcode("M960 S5 P" + (checked ? 1 : 0));
+                X1Plus.Settings.put("leds.toolhead", checked);
+                X1Plus.sendGcode(gcode.M960.toolhead(checked ? 1 : 0));
             }
         }
     }

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/Settings.js
@@ -80,4 +80,6 @@ function awaken() {
     _migrate("cfw_print_image", "homescreen.image.printing");
     _migrate("cfw_rootpw", "ssh.root_password");
     _migrate("cfw_sshd", "ssh.enabled");
+    _migrate("cfw_toolhead_led", "leds.toolhead");
+    _migrate("cfw_brightness", "lcd.brightness");
 }


### PR DESCRIPTION
The LCD brightness and toolhead LED settings are still set by Devicemanager. This migrates those settings.

New keys:

`leds.toolhead` 

`lcd.brightness`