### PR TITLE
Add PMSA003I i2c Driver

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -151,3 +151,67 @@ class Aht20Driver():
             await asyncio.sleep(self.interval_ms / 1000.0)
     
 I2cDriver.DEVICE_DRIVERS['aht20'] = Aht20Driver
+
+class Pm25Driver():
+    
+    def __init__(self, address, i2c_driver, config):
+        self.sensors = i2c_driver.daemon.sensors
+
+        self.pm25 = i2c_driver.i2c.get_port(address)
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/pm25")
+        
+        self.task = asyncio.create_task(self._task())
+        logger.info(f"probed PM25 sensor at 0x{address:2x}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+   
+    async def _task(self):
+        while True:
+            try:
+            
+                did_read = False
+                da = None
+                for i in range(20):
+                    da = self.pm25.read(readlen = 32)
+                    if da[0] == 0x42 and da[1] == 0x4D:
+                        did_read = True
+                        break
+                    await asyncio.sleep(0.01)
+                if not did_read or da is None:
+                    raise Exception("PM25 did not finish measuring")
+
+                # Standard Concentration µg/m^3
+                pm1_0_ugm3_std = (da[4] << 8) | da[5]
+                pm2_5_ugm3_std = (da[6] << 8) | da[7]
+                pm10_ugm3_std = (da[8] << 8) | da[9]
+                
+                # Environmental Concentration µg/m^3 - Useful
+                pm1_0_ugm3_env = (da[10] << 8) | da[11]
+                pm2_5_ugm3_env = (da[12] << 8) | da[13]
+                pm10_ugm3_env = (da[14] << 8) | da[15]
+                
+                # Particles Greater Than <particle_size>μm / 0.1L air
+                pm0_3_conc = (da[16] << 8) | da[17]
+                pm0_5_conc = (da[18] << 8) | da[19]
+                pm1_0_conc = (da[20] << 8) | da[21]
+                pm2_5_conc = (da[22] << 8) | da[23]
+                pm5_0_conc = (da[24] << 8) | da[25]
+                pm10_conc = (da[26] << 8) | da[27]
+                     
+                await self.sensors.publish(self.name, type = 'pm25',
+                    pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,
+                    pm1_0_ugm3 = pm1_0_ugm3_env, pm2_5_ugm3 = pm2_5_ugm3_env, pm10_ugm3 = pm10_ugm3_env, 
+                    pm0_3_conc = pm0_3_conc, pm0_5_conc = pm0_5_conc, pm1_0_conc = pm1_0_conc, 
+                    pm2_5_conc = pm2_5_conc, pm5_0_conc = pm5_0_conc, pm10_conc = pm10_conc)
+            except Exception as e:
+                await self.sensors.publish(self.name, type = 'pm25', inop = { 'exception': f"{e.__class__.__name__}: {e}" })
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)
+
+I2cDriver.DEVICE_DRIVERS['pm25'] = Pm25Driver

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -54,7 +54,7 @@ class MQTTClient():
                 
                 password = None
                 if os.path.isfile("/config/device/access_token"):
-                    password = open("/config/device/access_token", "r").read()
+                    password = open("/config/device/access_token", "r").read().strip()
                 password = self.daemon.settings.get("mqtt.override.password", password)
                 
                 self.sn = self.daemon.settings.get("mqtt.override.sn", None)


### PR DESCRIPTION
Adds an i2c driver for a PMSA003I sensor

Tested with the following sensor: [PMSA003I Air Quality Sensor](https://www.adafruit.com/product/4632)

### Sample Settings

`x1plus settings set expansion.port_b --json '{ "i2c":  { "0x12": { "pmsa003i": {"name": "particulate_matter", "interval_ms": 30000 } } } }'`   has 30s intervals.

Tested with 1s, 5s, 10s, and 30s intervals. Kept it at 30s since most air quality sensors usually go at 15, 30 or 60s intervals anyways, and it's not something that needs instant data for most use cases.

Hooked up to the i2c port on the expansion board ( X1P-002-B02 ). Since it is stemma-qt and not stemma, a converter cable was made.

### Published MQTT Data Sample

```json
{
    "x1plus": {
        "sensor": {
            "particulate_matter": {
                "pm0_3_conc": 378,
                "pm0_5_conc": 106,
                "pm10_conc": 0,
                "pm10_ugm3": 2,
                "pm10_ugm3_std": 2,
                "pm1_0_conc": 6,
                "pm1_0_ugm3": 1,
                "pm1_0_ugm3_std": 1,
                "pm2_5_conc": 1,
                "pm2_5_ugm3": 1,
                "pm2_5_ugm3_std": 1,
                "pm5_0_conc": 1,
                "timestamp": 1729447491.8341037,
                "type": "pmsa003i"
            }
        }
    }
}
```

Stress tested through a few prints with PETG and ASA. Definitely works with ASA getting PM 0.3+ concentrations in the thousands, meanwhile PETG was still sub 1000, only slightly above ambient or equal to.

## Other fixes

Includes a fix for #385 , stripping access_token from file read to remove excess whitespace characters. 

fixes #385 