### PR TITLE
x1plusd: pmsa003i driver error correction

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -163,7 +163,7 @@ class Pmsa003iDriver():
         
         self.interval_ms = int(config.get('interval_ms', 1000))
         self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
-        self.error_correction = config.get('error_correction', False)
+        self.overflow_mitigation = config.get('overflow_mitigation', False)
         
         
         self.task = asyncio.create_task(self._task())
@@ -208,33 +208,33 @@ class Pmsa003iDriver():
                 pm5_0_conc = (da[24] << 8) | da[25]
                 pm10_conc = (da[26] << 8) | da[27]
                 
-                # Overflow correction from 16bit limit
+                # Overflow mitigation from 16bit limit
                 if pm5_0_conc < pm10_conc:
-                    if self.error_correction:
+                    if self.overflow_mitigation:
                         pm5_0_conc += 65535
                     else: 
                         pm5_0_conc = -1
                         logger.info(f"{self.device_type.upper()} {self.name} value for PM > 5.0 Concentation is out of range (>65535)")
                 if pm2_5_conc < pm5_0_conc:
-                    if self.error_correction:
+                    if self.overflow_mitigation:
                         pm2_5_conc += 65535
                     else: 
                         pm2_5_conc = -1
                         logger.info(f"{self.device_type.upper()} {self.name} value for PM > 2.5 Concentation is out of range (>65535)")
                 if pm1_0_conc < pm2_5_conc:
-                    if self.error_correction:
+                    if self.overflow_mitigation:
                         pm1_0_conc += 65535
                     else: 
                         pm1_0_conc = -1
                         logger.info(f"{self.device_type.upper()} {self.name} value for PM > 1.0 Concentation is out of range (>65535)")
                 if pm0_5_conc < pm1_0_conc:
-                    if self.error_correction:
+                    if self.overflow_mitigation:
                         pm0_5_conc += 65535
                     else: 
                         pm0_5_conc = -1
                         logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.5 Concentation is out of range (>65535)")
                 if pm0_3_conc < pm0_5_conc:
-                    if self.error_correction:
+                    if self.overflow_mitigation:
                         pm0_3_conc += 65535
                     else: 
                         pm0_3_conc = -1
@@ -244,7 +244,7 @@ class Pmsa003iDriver():
                     pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,
                     pm1_0_ugm3 = pm1_0_ugm3_env, pm2_5_ugm3 = pm2_5_ugm3_env, pm10_ugm3 = pm10_ugm3_env, 
                     pm0_3_conc = pm0_3_conc, pm0_5_conc = pm0_5_conc, pm1_0_conc = pm1_0_conc, 
-                    pm2_5_conc = pm2_5_conc, pm5_0_conc = pm5_0_conc, pm10_conc = pm10_conc, error_correction=self.error_correction)
+                    pm2_5_conc = pm2_5_conc, pm5_0_conc = pm5_0_conc, pm10_conc = pm10_conc, overflow_mitigation=self.overflow_mitigation)
             except Exception as e:
                 await self.sensors.publish(self.name, type = self.device_type, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
             

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -203,7 +203,19 @@ class Pmsa003iDriver():
                 pm2_5_conc = (da[22] << 8) | da[23]
                 pm5_0_conc = (da[24] << 8) | da[25]
                 pm10_conc = (da[26] << 8) | da[27]
-                     
+                
+                # Overflow correction from 16bit limit
+                while pm5_0_conc < pm10_conc:
+                    pm5_0_conc += 65535
+                while pm2_5_conc < pm5_0_conc:
+                    pm2_5_conc += 65535
+                while pm1_0_conc < pm2_5_conc:
+                    pm1_0_conc += 65535
+                while pm0_5_conc < pm1_0_conc:
+                    pm0_5_conc += 65535
+                while pm0_3_conc < pm0_5_conc:
+                    pm0_3_conc += 65535
+
                 await self.sensors.publish(self.name, type = 'pmsa003i',
                     pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,
                     pm1_0_ugm3 = pm1_0_ugm3_env, pm2_5_ugm3 = pm2_5_ugm3_env, pm10_ugm3 = pm10_ugm3_env, 


### PR DESCRIPTION
Adds error correction to the concentration values of the pmsa003i i2c driver.

Sensor values, especially the >0.3 concentration value, can sometimes exceed the max unsigned int (16bit) of 65535. This can be detected if the value of >0.5 is larger than >0.3, and such a rule works for all pairs upward.

This was exhibited when printing with PETG-CF, and reproduced manually by holding a soldering iron with a plastic-welding tip near the sensor, with plastic such that it was smoking a bit. 

To address this, the pmsa003i config can now accept a new parameter "overflow_mitigation", which is false by default.

If true, for each concentration value detected to be less than the one greater (except 10.0, as nothing is greater, but it is exceedingly rare for this to be above the max 16bit int), it will add 65535 to the value.

If false, it will set the value to -1, indicating an overflow error, and additional INFO level logging will be supplied for the respective concentration value.

Additionally, the current setting for overflow_mitigation is added to the published results, so the end-user can know if they can expect -1 or >65535 when a value overflows. This way, output is always of the same type, but can clearly indicate what has happened to the data in either case.

Ex settings:

`x1plus settings set expansion.port_b --json '{ "i2c":  { "0x12": { "pmsa003i": {"name": "particulate_matter", "interval_ms": 30000, "overflow_mitigation": true } } } }'`