### PR TITLE
x1plusd: Dynamic loading of i2c drivers

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -1,5 +1,7 @@
 import os
 import logging
+import importlib.util
+import inspect
 
 import pyftdi.i2c
 import binascii
@@ -11,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 class I2cDriver():
     DEVICE_DRIVERS = {}
+    DRIVER_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), './i2c_drivers')
     
     def __init__(self, daemon, config, ftdi_path, port_name):
         self.ftdi_path = ftdi_path
@@ -21,13 +24,32 @@ class I2cDriver():
         self.daemon = daemon
         self.devices = []
         
+        self.drivers = {}
+        
+        # Load all valid driver classes from directory
+        for filename in os.listdir(self.DRIVER_DIR):
+            if filename.endswith('.py'):
+                module_name = filename[:-3]
+                driver_path = os.path.join(self.DRIVER_DIR, filename)
+                spec = importlib.util.spec_from_file_location(module_name, driver_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                
+                for name, driver in inspect.getmembers(module, inspect.isclass):
+                    if hasattr(driver, 'device_type'): 
+                        self.DEVICE_DRIVERS[driver.device_type] = driver
+        
         # I2C config format is just a dict of addresses -> devices
         for address, devices in config.items():
             address = int(address, 0)
             
             for device, subconfig in devices.items():
                 try:
-                    self.devices.append(self.DEVICE_DRIVERS[device](address = address, i2c_driver = self, config = subconfig))
+                    # Only load device with driver if requested by I2C config
+                    if driver := self.DEVICE_DRIVERS.get(device, None):
+                        self.devices.append(driver(address = address, i2c_driver = self, config = subconfig, logger = logger))
+                    else:
+                        logger.error(f"failed to initialize driver for {device}@0x{address:2x} on {ftdi_path}. Compatible driver not found")
                 except Exception as e:
                     logger.error(f"failed to initialize {device}@0x{address:2x} on {ftdi_path}: {e.__class__.__name__}: {e}")
     
@@ -36,218 +58,3 @@ class I2cDriver():
         for d in self.devices:
             d.disconnect()
         self.i2c.close()
-
-class Sht41Driver():
-    CMD_SERIAL_NUMBER = 0x89
-    CMD_MEASURE_HIGH_PRECISION = 0xFD
-
-    def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.daemon.sensors
-
-        self.sht41 = i2c_driver.i2c.get_port(address)
-
-        self.sht41.write((self.CMD_SERIAL_NUMBER, ))
-        sn = self.sht41.read(readlen = 6)
-        self.sn = binascii.hexlify(sn[0:2] + sn[3:5]).decode()
-        
-        self.interval_ms = int(config.get('interval_ms', 1000))
-        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/sht41/{self.sn}")
-        
-        self.task = asyncio.create_task(self._task())
-        logger.info(f"probed SHT41 sensor at 0x{address:2x} with serial number {self.sn}")
-
-    def disconnect(self):
-        if self.task:
-            self.task.cancel()
-            self.task = None
-    
-    async def _task(self):
-        while True:
-            try:
-                self.sht41.write((self.CMD_MEASURE_HIGH_PRECISION, ))
-                da = self.sht41.read(readlen = 6)
-                t_raw = int.from_bytes(da[0:2], "big")
-                rh_raw = int.from_bytes(da[3:5], "big")
-            
-                t_C = -45 + 175 * t_raw / 65535
-                rh_pct = -6 + 125 * rh_raw/65535
-            
-                await self.sensors.publish(self.name, type = 'sht41', serial = self.sn, t_c = t_C, rh_pct = rh_pct)
-            except Exception as e:
-                await self.sensors.publish(self.name, type = 'sht41', serial = self.sn, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
-            
-            await asyncio.sleep(self.interval_ms / 1000.0)
-    
-I2cDriver.DEVICE_DRIVERS['sht41'] = Sht41Driver
-
-class Aht20Driver():
-    CMD_RESET = 0xBA
-    CMD_INITIALIZE = 0xE1
-    CMD_MEASURE = 0xAC
-
-    def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.daemon.sensors
-
-        self.aht20 = i2c_driver.i2c.get_port(address)
-
-        self.aht20.write((self.CMD_RESET, ))
-        time.sleep(0.05)
-        
-        self.aht20.write(b'\xE1\x08\x00')
-        time.sleep(0.02)
-        self.aht20.write(b'\xBE\x08\x00')
-
-        did_init = False
-        for i in range(10):
-            time.sleep(0.02)
-            rv = self.aht20.read(readlen = 1)
-            if (rv[0] & 0x88) == 0x08:
-                did_init = True
-                break
-        if not did_init:
-            raise Exception("AHT20 never calibrated")
-        
-        self.aht20.write(b'\x71')
-        
-        self.interval_ms = int(config.get('interval_ms', 1000))
-        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/aht20")
-        
-        self.task = asyncio.create_task(self._task())
-        logger.info(f"probed AHT20 sensor at 0x{address:2x}")
-
-    def disconnect(self):
-        if self.task:
-            self.task.cancel()
-            self.task = None
-    
-    async def _task(self):
-        while True:
-            try:
-                self.aht20.write(b'\xAC\x33\x00')#(self.CMD_MEASURE, 0x33, 0x00, ))
-                await asyncio.sleep(0.01)
-                
-                did_read = False
-                for i in range(10):
-                    da = self.aht20.read(readlen = 1)
-                    if da[0] & 0x80 == 0:
-                        did_read = True
-                        break
-                    await asyncio.sleep(0.01)
-                if not did_read:
-                    raise Exception("AHT20 did not finish measuring")
-
-                da = self.aht20.read(readlen = 6)
-                
-                rh_raw = (da[1] << 12) | (da[2] << 4) | (da[3] >> 4)
-                rh_pct = (rh_raw * 100) / 0x100000
-                
-                t_raw = ((da[3] & 0xF) << 16) | (da[4] << 8) | da[5]
-                t_C = ((t_raw * 200.0) / 0x100000) - 50                
-
-                await self.sensors.publish(self.name, type = 'aht20', t_c = t_C, rh_pct = rh_pct)
-            except Exception as e:
-                await self.sensors.publish(self.name, type = 'aht20', inop = { 'exception': f"{e.__class__.__name__}: {e}" })
-            
-            await asyncio.sleep(self.interval_ms / 1000.0)
-    
-I2cDriver.DEVICE_DRIVERS['aht20'] = Aht20Driver
-
-class Pmsa003iDriver():
-
-    device_type = 'pmsa003i'
-    
-    def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.daemon.sensors
-
-        self.pmsa003i = i2c_driver.i2c.get_port(address)
-        
-        self.interval_ms = int(config.get('interval_ms', 1000))
-        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
-        self.overflow_mitigation = config.get('overflow_mitigation', False)
-        
-        
-        self.task = asyncio.create_task(self._task())
-        logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
-
-    def disconnect(self):
-        if self.task:
-            self.task.cancel()
-            self.task = None
-    
-   
-    async def _task(self):
-        while True:
-            try:
-            
-                did_read = False
-                da = None
-                for i in range(20):
-                    da = self.pmsa003i.read(readlen = 32)
-                    if da[0] == 0x42 and da[1] == 0x4D:
-                        did_read = True
-                        break
-                    await asyncio.sleep(0.01)
-                if not did_read or da is None:
-                    raise Exception(f"{self.device_type.upper()} did not finish measuring")
-
-                # Standard Concentration µg/m^3
-                pm1_0_ugm3_std = (da[4] << 8) | da[5]
-                pm2_5_ugm3_std = (da[6] << 8) | da[7]
-                pm10_ugm3_std = (da[8] << 8) | da[9]
-                
-                # Environmental Concentration µg/m^3 - Useful
-                pm1_0_ugm3_env = (da[10] << 8) | da[11]
-                pm2_5_ugm3_env = (da[12] << 8) | da[13]
-                pm10_ugm3_env = (da[14] << 8) | da[15]
-                
-                # Particles Greater Than <particle_size>μm / 0.1L air
-                pm0_3_conc = (da[16] << 8) | da[17]
-                pm0_5_conc = (da[18] << 8) | da[19]
-                pm1_0_conc = (da[20] << 8) | da[21]
-                pm2_5_conc = (da[22] << 8) | da[23]
-                pm5_0_conc = (da[24] << 8) | da[25]
-                pm10_conc = (da[26] << 8) | da[27]
-                
-                # Overflow mitigation from 16bit limit
-                if pm5_0_conc < pm10_conc:
-                    if self.overflow_mitigation:
-                        pm5_0_conc += 65535
-                    else: 
-                        pm5_0_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 5.0 Concentation is out of range (>65535)")
-                if pm2_5_conc < pm5_0_conc:
-                    if self.overflow_mitigation:
-                        pm2_5_conc += 65535
-                    else: 
-                        pm2_5_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 2.5 Concentation is out of range (>65535)")
-                if pm1_0_conc < pm2_5_conc:
-                    if self.overflow_mitigation:
-                        pm1_0_conc += 65535
-                    else: 
-                        pm1_0_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 1.0 Concentation is out of range (>65535)")
-                if pm0_5_conc < pm1_0_conc:
-                    if self.overflow_mitigation:
-                        pm0_5_conc += 65535
-                    else: 
-                        pm0_5_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.5 Concentation is out of range (>65535)")
-                if pm0_3_conc < pm0_5_conc:
-                    if self.overflow_mitigation:
-                        pm0_3_conc += 65535
-                    else: 
-                        pm0_3_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.3 Concentation is out of range (>65535)")
-
-                await self.sensors.publish(self.name, type = self.device_type,
-                    pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,
-                    pm1_0_ugm3 = pm1_0_ugm3_env, pm2_5_ugm3 = pm2_5_ugm3_env, pm10_ugm3 = pm10_ugm3_env, 
-                    pm0_3_conc = pm0_3_conc, pm0_5_conc = pm0_5_conc, pm1_0_conc = pm1_0_conc, 
-                    pm2_5_conc = pm2_5_conc, pm5_0_conc = pm5_0_conc, pm10_conc = pm10_conc, overflow_mitigation=self.overflow_mitigation)
-            except Exception as e:
-                await self.sensors.publish(self.name, type = self.device_type, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
-            
-            await asyncio.sleep(self.interval_ms / 1000.0)
-
-I2cDriver.DEVICE_DRIVERS[Pmsa003iDriver.device_type] = Pmsa003iDriver

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
@@ -1,0 +1,75 @@
+import asyncio
+import time
+
+class Aht20Driver():
+    CMD_RESET = 0xBA
+    CMD_INITIALIZE = 0xE1
+    CMD_MEASURE = 0xAC
+    
+    device_type = 'aht20'
+
+    def __init__(self, address, i2c_driver, config, logger):
+        self.logger = logger
+        self.sensors = i2c_driver.daemon.sensors
+
+        self.aht20 = i2c_driver.i2c.get_port(address)
+
+        self.aht20.write((self.CMD_RESET, ))
+        time.sleep(0.05)
+        
+        self.aht20.write(b'\xE1\x08\x00')
+        time.sleep(0.02)
+        self.aht20.write(b'\xBE\x08\x00')
+
+        did_init = False
+        for i in range(10):
+            time.sleep(0.02)
+            rv = self.aht20.read(readlen = 1)
+            if (rv[0] & 0x88) == 0x08:
+                did_init = True
+                break
+        if not did_init:
+            raise Exception(f"{self.device_type.upper()} never calibrated")
+        
+        self.aht20.write(b'\x71')
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
+        
+        self.task = asyncio.create_task(self._task())
+        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+    async def _task(self):
+        while True:
+            try:
+                self.aht20.write(b'\xAC\x33\x00')#(self.CMD_MEASURE, 0x33, 0x00, ))
+                await asyncio.sleep(0.01)
+                
+                did_read = False
+                for i in range(10):
+                    da = self.aht20.read(readlen = 1)
+                    if da[0] & 0x80 == 0:
+                        did_read = True
+                        break
+                    await asyncio.sleep(0.01)
+                if not did_read:
+                    raise Exception(f"{self.device_type.upper()} did not finish measuring")
+
+                da = self.aht20.read(readlen = 6)
+                
+                rh_raw = (da[1] << 12) | (da[2] << 4) | (da[3] >> 4)
+                rh_pct = (rh_raw * 100) / 0x100000
+                
+                t_raw = ((da[3] & 0xF) << 16) | (da[4] << 8) | da[5]
+                t_C = ((t_raw * 200.0) / 0x100000) - 50                
+
+                await self.sensors.publish(self.name, type = self.device_type, t_c = t_C, rh_pct = rh_pct)
+            except Exception as e:
+                await self.sensors.publish(self.name, type = self.device_type, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
@@ -1,0 +1,101 @@
+import asyncio
+import time
+
+class Pmsa003iDriver():
+
+    device_type = 'pmsa003i'
+    
+    def __init__(self, address, i2c_driver, config, logger):
+        self.logger = logger
+        self.sensors = i2c_driver.daemon.sensors
+
+        self.pmsa003i = i2c_driver.i2c.get_port(address)
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
+        self.overflow_mitigation = config.get('overflow_mitigation', False)
+        
+        
+        self.task = asyncio.create_task(self._task())
+        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+   
+    async def _task(self):
+        while True:
+            try:
+            
+                did_read = False
+                da = None
+                for i in range(20):
+                    da = self.pmsa003i.read(readlen = 32)
+                    if da[0] == 0x42 and da[1] == 0x4D:
+                        did_read = True
+                        break
+                    await asyncio.sleep(0.01)
+                if not did_read or da is None:
+                    raise Exception(f"{self.device_type.upper()} did not finish measuring")
+
+                # Standard Concentration µg/m^3
+                pm1_0_ugm3_std = (da[4] << 8) | da[5]
+                pm2_5_ugm3_std = (da[6] << 8) | da[7]
+                pm10_ugm3_std = (da[8] << 8) | da[9]
+                
+                # Environmental Concentration µg/m^3 - Useful
+                pm1_0_ugm3_env = (da[10] << 8) | da[11]
+                pm2_5_ugm3_env = (da[12] << 8) | da[13]
+                pm10_ugm3_env = (da[14] << 8) | da[15]
+                
+                # Particles Greater Than <particle_size>μm / 0.1L air
+                pm0_3_conc = (da[16] << 8) | da[17]
+                pm0_5_conc = (da[18] << 8) | da[19]
+                pm1_0_conc = (da[20] << 8) | da[21]
+                pm2_5_conc = (da[22] << 8) | da[23]
+                pm5_0_conc = (da[24] << 8) | da[25]
+                pm10_conc = (da[26] << 8) | da[27]
+                
+                # Overflow mitigation from 16bit limit
+                if pm5_0_conc < pm10_conc:
+                    if self.overflow_mitigation:
+                        pm5_0_conc += 65535
+                    else: 
+                        pm5_0_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 5.0 Concentation is out of range (>65535)")
+                if pm2_5_conc < pm5_0_conc:
+                    if self.overflow_mitigation:
+                        pm2_5_conc += 65535
+                    else: 
+                        pm2_5_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 2.5 Concentation is out of range (>65535)")
+                if pm1_0_conc < pm2_5_conc:
+                    if self.overflow_mitigation:
+                        pm1_0_conc += 65535
+                    else: 
+                        pm1_0_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 1.0 Concentation is out of range (>65535)")
+                if pm0_5_conc < pm1_0_conc:
+                    if self.overflow_mitigation:
+                        pm0_5_conc += 65535
+                    else: 
+                        pm0_5_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.5 Concentation is out of range (>65535)")
+                if pm0_3_conc < pm0_5_conc:
+                    if self.overflow_mitigation:
+                        pm0_3_conc += 65535
+                    else: 
+                        pm0_3_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.3 Concentation is out of range (>65535)")
+
+                await self.sensors.publish(self.name, type = self.device_type,
+                    pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,
+                    pm1_0_ugm3 = pm1_0_ugm3_env, pm2_5_ugm3 = pm2_5_ugm3_env, pm10_ugm3 = pm10_ugm3_env, 
+                    pm0_3_conc = pm0_3_conc, pm0_5_conc = pm0_5_conc, pm1_0_conc = pm1_0_conc, 
+                    pm2_5_conc = pm2_5_conc, pm5_0_conc = pm5_0_conc, pm10_conc = pm10_conc, overflow_mitigation=self.overflow_mitigation)
+            except Exception as e:
+                await self.sensors.publish(self.name, type = self.device_type, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
@@ -1,0 +1,48 @@
+import binascii
+
+import asyncio
+import time
+
+class Sht41Driver():
+    CMD_SERIAL_NUMBER = 0x89
+    CMD_MEASURE_HIGH_PRECISION = 0xFD
+    
+    device_type = 'sht41'
+
+    def __init__(self, address, i2c_driver, config, logger):
+        self.logger = logger
+        self.sensors = i2c_driver.daemon.sensors
+
+        self.sht41 = i2c_driver.i2c.get_port(address)
+
+        self.sht41.write((self.CMD_SERIAL_NUMBER, ))
+        sn = self.sht41.read(readlen = 6)
+        self.sn = binascii.hexlify(sn[0:2] + sn[3:5]).decode()
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}/{self.sn}")
+        
+        self.task = asyncio.create_task(self._task())
+        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x} with serial number {self.sn}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+    async def _task(self):
+        while True:
+            try:
+                self.sht41.write((self.CMD_MEASURE_HIGH_PRECISION, ))
+                da = self.sht41.read(readlen = 6)
+                t_raw = int.from_bytes(da[0:2], "big")
+                rh_raw = int.from_bytes(da[3:5], "big")
+            
+                t_C = -45 + 175 * t_raw / 65535
+                rh_pct = -6 + 125 * rh_raw/65535
+            
+                await self.sensors.publish(self.name, type = self.device_type, serial = self.sn, t_c = t_C, rh_pct = rh_pct)
+            except Exception as e:
+                await self.sensors.publish(self.name, type = self.device_type, serial = self.sn, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)


### PR DESCRIPTION
An initial implementation for dynamic loading of i2c drivers, as well as separating them out from i2c.py.

Rather than implementing a complete registration/deregistration service, this takes advantage of the i2c interface being reloaded when the config for it is changed.

### Steps

- A new directory is created to house each driver file, which *must* contain the `device_type` attribute.

- On i2c init (on boot and on each expansion port config update), it will scan this directory for all py files, load initially each module/class and check if it has the device_type attribute, if so, it adds that to the known DEVICE_DRIVERS. 

- Then when parsing the i2c config, it will only load a device and its associated driver if one matches a known device_type. If none are found, an error log is produced stating no compatible drivers are found.

This works quite well given that updating the i2c config reloads it all anyways, this simply hooks into that behaviour.

I expect quite a few changes necessary, one thing I am looking for is a better method of driver class validation. Something that would also verify the format is as expected.

Example screenshot of logs after reloading the config after adding new driver files and changing device_types in config and files to match/mismatch (was messing with SHT41 driver).

![image](https://github.com/user-attachments/assets/8dcab460-48b5-4acb-a232-ee15defa63a2)

Closes #386
