### PR TITLE
x1plusd: add b64zjson format for `;x1plus define`

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/client/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/client/__init__.py
@@ -1,5 +1,6 @@
 from . import ota
 from . import settings
 from . import actions
+from . import convert
 
-__all__ = ['ota', 'settings', 'actions']
+__all__ = ['ota', 'settings', 'actions', 'convert']

--- a/images/cfw/opt/x1plus/lib/python/x1plus/client/__main__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/client/__main__.py
@@ -1,5 +1,5 @@
 import argparse
-from . import ota, settings, actions
+from . import ota, settings, actions, convert
 
 """
 Basic command-line X1Plus management tool.
@@ -11,6 +11,7 @@ subparsers = parser.add_subparsers(title = 'commands', required = True)
 ota.add_subparser(subparsers)
 settings.add_subparser(subparsers)
 actions.add_subparser(subparsers)
+convert.add_subparser(subparsers)
 
 args = parser.parse_args()
 args.func(args)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/client/actions.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/client/actions.py
@@ -10,6 +10,7 @@ def execute(action):
 ###
 
 import json, yaml
+import sys
 
 def _cmd_execute(args):
     value = args.action[0]
@@ -44,6 +45,7 @@ def _cmd_execute(args):
                 value = yaml.safe_load(value)
             except:
                 print(f"'{value}' could not be parsed as either JSON or YAML", file=sys.stderr)
+                sys.exit(1)
     
     print("executing action:")
     print(json.dumps(value, indent=4))

--- a/images/cfw/opt/x1plus/lib/python/x1plus/client/convert.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/client/convert.py
@@ -1,0 +1,81 @@
+import json, yaml
+import zlib
+import base64
+import sys
+
+def _cmd_convert(args):
+    value = args.action[0]
+    
+    if args.file:
+        if value[-5:] == ".json":
+            args.json = True
+        if value[-5:] == ".yaml" or value[-4:] == ".yml":
+            args.yaml = True
+        with open(value) as f:
+            value = f.read()
+
+    if args.yaml:
+        try:
+            value = yaml.safe_load(value)
+        except Exception as e:
+            print(f"'{value}' does not look like valid YAML to me: {e}", file=sys.stderr)
+            sys.exit(1)
+    elif args.json:
+        try:
+            value = json.loads(value)
+        except Exception as e:
+            print(f"'{value}' does not look like valid JSON to me: {e}", file=sys.stderr)
+            sys.exit(1)
+    elif args.b64:
+        try:
+            value = base64.b64decode(value, validate=True)
+        except Exception as e:
+            print(f"value did not look like valid base64 to me: {e}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            value = zlib.decompress(value)
+        except Exception as e:
+            print(f"value did not look like valid zlib stream inside of base64 to me: {e}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            value = json.loads(value)
+        except Exception as e:
+            print(f"value did not look like valid JSON inside of zlib inside of base64 to me: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        # Well, let's try some stuff.
+        try:
+            zvalue = base64.b64decode(value, validate=True)
+            zvalue = zlib.decompress(zvalue)
+            value = json.loads(zvalue)
+        except:
+            try:
+                # This will catch things that look like numbers, and quoted strings, and, of course, actual honest-to-god JSON.
+                value = json.loads(value)
+            except:
+                try:
+                    value = yaml.safe_load(value)
+                except:
+                    print(f"'{value}' could not be parsed as either JSON or YAML or X1Plus Gcode action", file=sys.stderr)
+                    sys.exit(1)
+    
+    if args.to is None or args.to[0] == 'b64':
+        print(base64.b64encode(zlib.compress(json.dumps(value).encode(), 9)).decode())
+    elif args.to[0] == 'json':
+        print(json.dumps(value, indent=4))
+    elif args.to[0] == 'yaml':
+        print(yaml.dump(value))
+    else:
+        print(f"unsupported output format {args.to[0]} (try 'b64', 'json', 'yaml')", file=sys.stderr)
+        sys.exit(1)
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser('convert', help="convert between various action and configuration formats")
+    parser.add_argument('action', action="store", nargs=1, help="string (or file) to convert (defaults to 'generous' parsing, can be overridden with individual parse options)")
+    parser.add_argument('--json', action="store_true", help="strictly interpret value as JSON")
+    parser.add_argument('--yaml', action="store_true", help="interpret value as YAML")
+    parser.add_argument('--b64', action="store_true", help="interpret value as X1Plus G-code format (b64zjson)")
+    parser.add_argument('--file', action="store_true", help="take input from a file")
+    parser.add_argument('--to', action="store", nargs=1, help="format to convert to (options are json, yaml, b64; defaults to b64)")
+    parser.set_defaults(func=_cmd_convert)
+    

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mcproto.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mcproto.py
@@ -1,4 +1,6 @@
 import re
+import base64
+import zlib
 import json
 import asyncio
 
@@ -296,10 +298,15 @@ class MCProtoParser():
                     continue
                 id = int(m[1])
                 try:
-                    val = json.loads(m[2])
-                except Exception as e:
-                    logger.error(f"x1plus define {id} (\"{m[2]}\") had invalid JSON: {e.__class__.__name__}: \"{e}\"")
-                    continue
+                    val = base64.b64decode(m[2])
+                    val = zlib.decompress(val)
+                    val = json.loads(val)
+                except Exception as e1:
+                    try:
+                        val = json.loads(m[2])
+                    except Exception as e:
+                        logger.error(f"x1plus define {id} (\"{m[2]}\") was neither valid b64zjson (\"{e1}\") nor valid JSON: {e.__class__.__name__}: \"{e}\"")
+                        continue
                 logger.info(f"found x1plus define {id} -> {val}")
                 self.gcode_x1plus_defs[id] = val
         


### PR DESCRIPTION
Previously, actions showed up in G-code as JSON blobs, but unfortunately, Slic3r-derived slicers (including Orca Slicer) choke on `{curly braces}` -- they use them as variable expansion, and it seems like there is no good way to escape them.  To avoid this, we add a text-safe `x1plus define` format that can be used where JSON would otherwise be used, which I call "b64zjson".  The definition of this is that b64zjson is valid JSON, wrapped in a zlib encoding (not: gzip), wrapped in Base64.

Handwriting b64zjson is a skill that takes some time to acquire, however, so we also introduce the command `x1plus convert`, which can convert a JSON string into b64zjson ready to be embedded in G-code:

```
[root@BL-P001-sdcard:~]# x1plus convert '[{"delay": 1.5}, {"gpio": {"action": "pulse", "duration": 0.6, "gpio": { "function": "buzzer" }}}, {"delay": 1.5}, {"gcode": "M400 W0"}]'
eNqLrlZKSc1JrFSyUjDUM63VUahWSi/IzAdyq5USk0sy8/OATKWC0pziVCUdBaWU0qJEqKCBnhlQAK44rTQPrjyptKoqtUipthZsHob5yfkpqSBlviYGBgrhBkq1sQDjmSiY
```

`x1plus convert` can also convert YAML:

```
[root@BL-P001-sdcard:~]# x1plus convert --file beep.yaml
eNqLrlZKL8jMV7JSqFZKTC7JzM8DMpUKSnOKU5V0FJRSSosSoYIGegYWQBG46rTSPLj64ozSkpLUIqXa2lodoFRKak5iJVQLWIB4K0yJsCIWACgsOUE=
```

and can also convert the other direction:

```
[root@BL-P001-sdcard:~]# x1plus convert --to=yaml eNqLrlZKSc1JrFSyUjDUM63VUahWSi/IzAdyq5USk0sy8/OATKWC0pziVCUdBaWU0qJEqKCBnhlQAK44rTQPrjyptKoqtUipthZsHob5yfkpqSBlviYGBgrhBkq1sQDj
mSiY
- delay: 1.5
- gpio:
    action: pulse
    duration: 0.6
    gpio:
      function: buzzer
- delay: 1.5
- gcode: M400 W0
```

You can try this out with Gcode similar to the following:

```
G21 
G90
M104 S0
G1 X192 Y192 F2000
G29.2 S1
G0 Z  15.000 

G0 X 100 Y 100 
G0 X 175 Y 100
;x1plus define 1 eNqLrlZKL8jMV7JSqFZKTC7JzM8DMpUKSnOKU5V0FJRSSosSoYIGeoZAAbjitNI8uPKk0qqq1CKl2tpaHaBMSmpOYiVYg4EpWICaFsQCAErtN/k=
M73 P25 R0
M976 S99 P1
G0 X 175 Y 175
M400
;x1plus define 2 eNqLrlZKL8jMV7JSqFZKTC7JzM8DMpUKSnOKU5V0FJRSSosSoYIGekZAAbjitNI8uPKk0qqq1CKl2tpaHaBMSmpOYiVEA5hPbfPTk/NTUkHCviYGBgrhBkq1sQAqoD14
M73 P50 R0
M976 S99 P2 
M400 W1
G0 X 100 Y 175
G0 X 100 Y 100
M73 P75 R0
M400
;x1plus define 3 eNqLrlZKSc1JrFSyUjDUM63VUahWSi/IzAdyq5USk0sy8/OATKWC0pziVCUdBaWU0qJEqKCBnhlQAK44rTQPrjyptKoqtUipthZsHob5yfkpqSBlviYGBgrhBkq1sQDjmSiY
M976 S99 P3 
M400 W1
G0 X 175 Y 100
G0 X 175 Y 175
M73 P100 R0
```