### PR TITLE
Revert "Add check if x1plusd is already running"

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__main__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__main__.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging, logging.handlers
-import os
 import setproctitle
 
 from . import X1PlusDaemon, logger
@@ -19,8 +18,6 @@ ch.setLevel(logging.DEBUG)
 ch.setFormatter(logging.Formatter("[%(asctime)s] %(name)s: %(levelname)s: %(message)s"))
 logger.addHandler(ch)
 
-PID_FILE = '/var/run/x1plusd.pid'
-
 
 def exceptions(loop, ctx):
     logger.error(f"exception in coroutine: {ctx['message']} {ctx.get('exception', '')}")
@@ -35,36 +32,13 @@ async def start():
     x1plusd = await X1PlusDaemon.create()
     await x1plusd.start()
 
-
-def is_already_running():
-    try:
-        with open(PID_FILE, 'r') as f:
-            pid = int(f.read().strip())
-        os.kill(pid, 0)  # Check if the process is still running
-        return True
-    except (IOError, ValueError, OSError):
-        return False
-
-
-# catchall exception
+# TODO: check if we are already running
+loop = asyncio.new_event_loop()
+loop.set_exception_handler(exceptions)
+loop.create_task(start())
 try:
-    # Check if we are already running
-    if is_already_running():
-        logger.error("x1plusd is already running. Exiting.")
-        exit(1)
-
-    # Create the PID file
-    with open(PID_FILE, 'w') as f:
-        f.write(str(os.getpid()))
-
-    loop = asyncio.new_event_loop()
-    loop.set_exception_handler(exceptions)
-    loop.create_task(start())
     loop.run_forever()
-except Exception as e:
-    logger.error(f"Exception occurred: {e}")
 finally:
     logger.error("x1plusd event loop has terminated!")
     loop.run_until_complete(loop.shutdown_asyncgens())
-    os.unlink(PID_FILE)
     loop.close()


### PR DESCRIPTION
#373 causes x1plusd to fail to start if launched from /etc/init.d/S72x1plusd (the pid file is created and then x1plusd sees its own shadow and goes back underground for another 6 weeks of winter).  We revert it.