### PR TITLE
x1plusd: Dynamic module and i2c loading

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -10,6 +10,16 @@ import x1plus.utils
 from .dbus import *
 from .settings import SettingsService
 
+from .ota import OTAService
+from .sshd import SSHService
+from .httpd import HTTPService
+from .mqtt import MQTTClient
+from .expansion import ExpansionManager
+from .sensors import SensorsService
+from .mcproto import MCProtoParser
+from .actions import ActionHandler
+from .gpios import GpioManager
+
 from x1plus.utils import module_loader, module_docstring_parser
 
 logger = logging.getLogger(__name__)
@@ -22,8 +32,7 @@ class X1PlusDaemon:
         "name": {
             "definition": {},
             "module_class": Class,
-            "path": "",
-            "loaded": true/false. If unable to load, deleted from modules
+            "loaded": true/false. False if error loading.
         }
     } 
     """
@@ -40,6 +49,23 @@ class X1PlusDaemon:
         self.router = await get_dbus_router()
         self.settings = SettingsService(router=self.router)
 
+        self.mqtt = MQTTClient(daemon=self)
+        self.ota = OTAService(router=self.router, daemon=self)
+        self.ssh = SSHService(daemon=self)
+        self.httpd = HTTPService(router=self.router, daemon=self)
+        self.sensors = SensorsService(router=self.router, daemon=self)
+        self.mcproto = MCProtoParser(daemon=self)
+        self.expansion = ExpansionManager(router=self.router, daemon=self)
+        self.gpios = GpioManager(daemon=self)
+        self.actions = ActionHandler(router=self.router, daemon=self)
+        
+        self.custom_modules = {}
+        """
+        { "name": ClassInstance }
+        """
+
+        self.settings_keys = []
+
         BASE_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
         # Custom module folder could be in x1plus.services.x1plusd.custom, and symlinked to sd card?
 
@@ -49,8 +75,6 @@ class X1PlusDaemon:
             full_path = os.path.join(BASE_MODULE_DIR, filename)
             if os.path.isdir(full_path) and not filename.startswith("_"):
                 directories.append(full_path)
-
-        self.settings_keys = []
 
         for directory in directories:
             if not os.path.isdir(directory):
@@ -65,13 +89,16 @@ class X1PlusDaemon:
                         module_data = module_docstring_parser(file_path, "x1plusd-module")
                         if not module_data or not module_data.get("class_name", None):
                             continue
+                        if not module_data.get("name", None):
+                            logger.warn(f"Missing required definitions in x1plusd module spec for {module_name}.")
+                            continue
 
                         package = None
                         if BASE_MODULE_DIR in directory:
                             root_package = "x1plus.services.x1plusd"
                             nested_dir = directory.replace(BASE_MODULE_DIR, "").replace("/", ".")
                             if nested_dir: 
-                                # One level deep, i.e., 'expansion', 'custom'
+                                # One level deep, i.e., 'custom'
                                 root_package = ".".join([root_package, nested_dir])
                                 root_package = root_package.replace("..", ".")
                             package = root_package
@@ -79,120 +106,75 @@ class X1PlusDaemon:
                             continue
 
                         module, module_name = module_loader(file_path, package)
+
                         """
                         [x1plusd-module]
                         name=name, required
                         class_name=ClassName, required
                         requires_router=bool, default: false
-                        settings_key=settings.path.for.bool, required
                         start_func=function_name, default: task, set as 'null' if it does not have a start function
-                        required_modules=module1,module2, default: none.
-                        default_state=bool, default: false. Determines its default enabled state when not present in settings
                         [end]
                         """
+
                         if not module:
                             continue
                         if not hasattr(module, module_data.get("class_name")):
                             logger.warn(f"Could not load {module_name} in x1plusd module loader. Class not found: {module_data.get("class_name")}")
                             continue
-                        if not module_data.get("name", None) or not module_data.get("settings_key", None):
-                            logger.warn(f"Missing required definitions in x1plusd module spec for {module_name}.")
+
+                        self.settings_keys.append(f"x1plusd.modules.{module_data.get("name")}")
+                        if not self.settings.get(f"x1plusd.modules.{module_data.get("name")}", False):
+                            # Module found, but disabled in settings. Do not load, but added to restart listener above
                             continue
 
-                        self.settings_keys.append(module_data.get("settings_key"))
                         module_class = getattr(module, module_data.get("class_name"))
-
+                        # Disabled modules will not get added at all currently
                         self.MODULES[module_data.get("name")] = {
                             "definition": module_data,
-                            "path": file_path,
                             "module_class": module_class,
                             "loaded": False
                         }
-                        try: 
-                            if module_data.get("start_func", "") == "null" and not module_data.get("required_modules", None):
-                                if not module_data.get("settings_key", None) or \
-                                   not self.settings.get(module_data.get("settings_key"), 
-                                                         module_data.get("default_state", "false").lower().strip() != "false") or \
-                                   not callable(module_class):
 
-                                    del self.MODULES[module_data.get("name")]
+                        try: 
+                            if module_data.get("start_func", "") == "null":
+                                if not callable(module_class):
                                     continue
 
-                                if module_data.get("requires_router", "false") == "false":
-                                    setattr(self, module_data.get("name"), module_class(daemon=self))
+                                if module_data.get("requires_router", "false").lower() == "false":
+                                    self.custom_modules[module_data.get("name")] = module_class(daemon=self)
                                 else:
-                                    setattr(self, module_data.get("name"), module_class(router=self.router, daemon=self))
+                                    self.custom_modules[module_data.get("name")] = module_class(router=self.router, daemon=self)
 
                                 self.MODULES[module_data.get("name")]["loaded"] = True
 
                         except Exception as e:
                             logger.error(f"Could not start x1plusd module {module_data.get("name")}. {e.__class__.__name__}: {e}")
-                            del self.MODULES[module_data.get("name")]
                 except Exception as e:
                     logger.error(f"Error loading x1plusd modules. {e.__class__.__name__}: {e}")
 
         modules_loaded = False
-        max_tries = 20
-        tries = 0
-        # TODO: Create a priority map order based on requirements instead
         try:
-            while not modules_loaded:
-                failed_modules = []
-                for name, module in self.MODULES.items():
-                    if not module.get("definition").get("settings_key", None) or \
-                       not self.settings.get(module.get("definition").get("settings_key"), 
-                                             module.get("definition").get("default_state", "false").lower().strip() != "false"):
-                        failed_modules.append(name)
-                        continue
-                    if hasattr(self, name) or module.get("loaded"):
-                        continue
-                    
-                    requirements = list(map(str.strip, module.get("definition").get("required_modules", "").lower().split(",")))
-                    if len(requirements) == 1 and requirements[0] == "":
-                        requirements = []
 
-                    if not requirements or all([hasattr(self, req_module) for req_module in requirements]):
-                        module_class = module.get("module_class")
-                        if not callable(module_class):
-                            failed_modules.append(name)
-                            continue
-                        try: 
+            for name, module in self.MODULES.items():
+                if module.get("loaded") or self.custom_modules.get(name, None):
+                    continue
+                
+                module_class = module.get("module_class")
+                if not callable(module_class):
+                    continue
+                try: 
 
-                            if module.get("definition", {}).get("requires_router", "false") == "false":
-                                setattr(self, name, module_class(daemon=self))
-                            else:
-                                setattr(self, name, module_class(router=self.router, daemon=self))
+                    if module.get("definition", {}).get("requires_router", "false").lower() == "false":
+                        self.custom_modules[name] = module_class(daemon=self)
+                    else:
+                        self.custom_modules[name] = module_class(router=self.router, daemon=self)
 
-                            module["loaded"] = True
+                    module["loaded"] = True
 
-                        except Exception as e:
-                            logger.error(f"Could not start x1plusd module {name}. {e.__class__.__name__}: {e}")
-                            failed_modules.append(name)
-                            continue
-                        continue
-
-                    if not all([self.MODULES.get(req_module, None) for req_module in requirements]):
-                        logger.error(f"Cannot load x1plusd module {name}. Not all required modules exist. Requires: {requirements}")
-                        failed_modules.append(name)
-                        continue
-
-                for failed in failed_modules:
-                    del self.MODULES[failed]
-                failed_modules.clear()
-
-                modules_loaded = all([hasattr(self, name) and module.get("loaded") for name, module in self.MODULES.items()])
-                tries += 1
-
-                if tries >= max_tries:
-                    logger.warn(f"Could not load all x1plusd modules")
-                    failed_modules = []
-                    for name, module in self.MODULES.items():
-                        if not module.get("loaded", False):
-                            failed_modules.append(name)
-                    for failed in failed_modules:
-                        del self.MODULES[failed]
-                    failed_modules.clear()
-                    break
+                except Exception as e:
+                    logger.error(f"Could not start x1plusd module {name}. {e.__class__.__name__}: {e}")
+                    continue
+                continue
 
         except Exception as e:
             logger.error(f"Error adding x1plusd modules. {e.__class__.__name__}: {e}")
@@ -201,17 +183,28 @@ class X1PlusDaemon:
 
     async def start(self):
         asyncio.create_task(self.settings.task())
+
+        asyncio.create_task(self.mqtt.task())
+        asyncio.create_task(self.ota.task())
+        asyncio.create_task(self.httpd.task())
+        asyncio.create_task(self.sensors.task())
+        asyncio.create_task(self.expansion.task())
+        asyncio.create_task(self.mcproto.task())
+        asyncio.create_task(self.actions.task())
         
         default_start_func = 'task'
 
         for name, module in self.MODULES.items():
+            if not module.get("loaded", False):
+                continue
+
             try: 
                 start_func = module.get('definition', {}).get('start_func', default_start_func)
                 if start_func != 'null':
-                    if not hasattr(getattr(self, name), start_func):
+                    if not self.custom_modules.get(name, None) or not hasattr(self.custom_modules.get(name), start_func):
                         logger.warn(f"Could not start task for x1plusd module {name}. Start function not found: {start_func}")
                         continue
-                    asyncio.create_task(getattr(getattr(self, name), start_func)())
+                    asyncio.create_task(getattr(self.custom_modules.get(name), start_func)())
             except Exception as e:
                 logger.error(f"Error starting x1plusd module {name}. {e.__class__.__name__}: {e}")
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__init__.py
@@ -1,58 +1,254 @@
 # Always invoke this with python3 -m x1plus.services.x1plusd.
 
 import asyncio
+import os
+import sys
+import re
+import importlib
 import logging, logging.handlers
 import x1plus.utils
 from .dbus import *
 from .settings import SettingsService
-from .ota import OTAService
-from .sshd import SSHService
-from .httpd import HTTPService
-from .mqtt import MQTTClient
-from .expansion import ExpansionManager
-from .sensors import SensorsService
-from .mcproto import MCProtoParser
-from .actions import ActionHandler
-from .gpios import GpioManager
 
 logger = logging.getLogger(__name__)
 
 class X1PlusDaemon:
+
+    MODULES = {}    
+    """
+    MODULES = {
+        "name": {
+            "definition": {},
+            "module_class": Class,
+            "path": "",
+            "loaded": true/false. If unable to load, deleted from modules
+        }
+    } 
+    """
+
+
     @classmethod
     async def create(cls):
         # must be a classmethod, since __init__ cannot be async
         self = X1PlusDaemon()
 
         logger.info("creating x1plusd services")
+        
+        # Required modules
         self.router = await get_dbus_router()
         self.settings = SettingsService(router=self.router)
-        self.mqtt = MQTTClient(daemon=self)
-        self.ota = OTAService(router=self.router, daemon=self)
-        self.ssh = SSHService(daemon=self)
-        self.httpd = HTTPService(router=self.router, daemon=self)
-        self.sensors = SensorsService(router=self.router, daemon=self)
-        self.gpios = GpioManager(daemon=self)
-        self.expansion = ExpansionManager(router=self.router, daemon=self)
-        self.mcproto = MCProtoParser(daemon=self)
-        self.actions = ActionHandler(router=self.router, daemon=self)
-        if not self.settings.get("polar_cloud", False):
-            self.polar_cloud = None
-        else:
-            from .polar_cloud import PolarPrintService
-            self.polar_cloud = PolarPrintService(daemon=self)
-        
+
+        BASE_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+        # Custom module folder could be in x1plus.services.x1plusd.custom, and symlinked to sd card?
+
+        directories = [BASE_MODULE_DIR]
+
+        for filename in os.listdir(BASE_MODULE_DIR):
+            full_path = os.path.join(BASE_MODULE_DIR, filename)
+            if os.path.isdir(full_path) and not filename.startswith("_"):
+                directories.append(full_path)
+
+        self.settings_keys = []
+
+        for directory in directories:
+            if not os.path.isdir(directory):
+                continue
+            for filename in os.listdir(directory):
+                try: 
+                    file_path = os.path.join(directory, filename)
+                    if not os.path.isfile(file_path):
+                        continue
+
+                    if filename.endswith(".py") and not filename.startswith("_"):
+                        module_data = self.module_parser(file_path)
+                        if not module_data or not module_data.get("class_name", None):
+                            continue
+
+                        package = None
+                        if BASE_MODULE_DIR in directory:
+                            root_package = "x1plus.services.x1plusd"
+                            nested_dir = directory.replace(BASE_MODULE_DIR, "").replace("/", ".")
+                            if nested_dir: 
+                                # One level deep, i.e., 'expansion', 'custom'
+                                root_package = ".".join([root_package, nested_dir])
+                                root_package = root_package.replace("..", ".")
+                            package = root_package
+                        if not package:
+                            continue
+
+                        module, module_name = self.load_module(file_path, package)
+                        """
+                        [x1plusd-module]
+                        name=name, required
+                        class_name=ClassName, required
+                        requires_router=bool, default: false
+                        settings_key=settings.path.for.bool, required
+                        start_func=function_name, default: task, set as 'null' if it does not have a start function
+                        required_modules=module1,module2, default: none.
+                        default_state=bool, default: false. Determines its default enabled state when not present in settings
+                        [end]
+                        """
+                
+                        if not hasattr(module, module_data.get("class_name")):
+                            logger.warn(f"Could not load {module_name} in x1plusd module loader. Class not found: {module_data.get("class_name")}")
+                            continue
+                        if not module_data.get("name", None) or not module_data.get("settings_key", None):
+                            logger.warn(f"Missing required definitions in x1plusd module spec for {module_name}.")
+                            continue
+
+                        self.settings_keys.append(module_data.get("settings_key"))
+                        module_class = getattr(module, module_data.get("class_name"))
+
+                        self.MODULES[module_data.get("name")] = {
+                            "definition": module_data,
+                            "path": file_path,
+                            "module_class": module_class,
+                            "loaded": False
+                        }
+                        try: 
+                            if module_data.get("start_func", "") == "null" and not module_data.get("required_modules", None):
+                                if not module_data.get("settings_key", None) or \
+                                   not self.settings.get(module_data.get("settings_key"), 
+                                                         module_data.get("default_state", "false").lower().strip() != "false") or \
+                                   not callable(module_class):
+
+                                    del self.MODULES[module_data.get("name")]
+                                    continue
+
+                                if module_data.get("requires_router", "false") == "false":
+                                    setattr(self, module_data.get("name"), module_class(daemon=self))
+                                else:
+                                    setattr(self, module_data.get("name"), module_class(router=self.router, daemon=self))
+
+                                self.MODULES[module_data.get("name")]["loaded"] = True
+
+                        except Exception as e:
+                            logger.error(f"Could not start x1plus module {module_data.get("name")}. {e.__class__.__name__}: {e}")
+                            del self.MODULES[module_data.get("name")]
+                except Exception as e:
+                    logger.error(f"Error loading x1plusd modules. {e.__class__.__name__}: {e}")
+
+        modules_loaded = False
+        max_tries = 20
+        tries = 0
+        # TODO: Create a priority map order based on requirements instead
+        try:
+            while not modules_loaded:
+                failed_modules = []
+                for name, module in self.MODULES.items():
+                    if not module.get("definition").get("settings_key", None) or \
+                       not self.settings.get(module.get("definition").get("settings_key"), 
+                                             module.get("definition").get("default_state", "false").lower().strip() != "false"):
+                        failed_modules.append(name)
+                        continue
+                    if hasattr(self, name) or module.get("loaded"):
+                        continue
+                    
+                    requirements = list(map(str.strip, module.get("definition").get("required_modules", "").lower().split(",")))
+                    if len(requirements) == 1 and requirements[0] == "":
+                        requirements = []
+
+                    if not requirements or all([hasattr(self, req_module) for req_module in requirements]):
+                        module_class = module.get("module_class")
+                        if not callable(module_class):
+                            failed_modules.append(name)
+                            continue
+                        try: 
+
+                            if module.get("definition", {}).get("requires_router", "false") == "false":
+                                setattr(self, name, module_class(daemon=self))
+                            else:
+                                setattr(self, name, module_class(router=self.router, daemon=self))
+
+                            module["loaded"] = True
+
+                        except Exception as e:
+                            logger.error(f"Could not start x1plus module {name}. {e.__class__.__name__}: {e}")
+                            failed_modules.append(name)
+                            continue
+                        continue
+
+                    if not all([self.MODULES.get(req_module, None) for req_module in requirements]):
+                        logger.error(f"Cannot load x1plusd module {name}. Not all required modules exist. Requires: {requirements}")
+                        failed_modules.append(name)
+                        continue
+
+                for failed in failed_modules:
+                    del self.MODULES[failed]
+                failed_modules.clear()
+
+                modules_loaded = all([hasattr(self, name) and module.get("loaded") for name, module in self.MODULES.items()])
+                tries += 1
+
+                if tries >= max_tries:
+                    logger.warn(f"Could not load all x1plusd modules")
+                    failed_modules = []
+                    for name, module in self.MODULES.items():
+                        if not module.get("loaded", False):
+                            failed_modules.append(name)
+                    for failed in failed_modules:
+                        del self.MODULES[failed]
+                    failed_modules.clear()
+                    break
+
+        except Exception as e:
+            logger.error(f"Error adding x1plusd modules. {e.__class__.__name__}: {e}")
+
         return self
 
+
+    def load_module(self, file_path, package_name):
+        module_name = os.path.splitext(os.path.basename(file_path))[0]
+        module = importlib.import_module(f"{package_name}.{module_name}")
+        return module, module_name
+
+
+    def module_parser(self, filepath: str) -> dict:
+        content = None
+        config = {}
+        try:
+            with open(filepath, "r") as file:
+                content = file.read()
+        except Exception as e:
+            logger.warn(f"Could not load {filepath} in module loader. {e.__class__.__name__}: {e}")
+            return config
+        
+        if not content:
+            return config
+
+        docstring_match = re.match(r"^([\"']{3})(.*?)\1", content, re.DOTALL)
+        if not docstring_match:
+            logger.debug(f"No docstring found for {filepath} for module loader")
+            return config
+        
+        docstring = docstring_match.group(2).strip()
+        module_block_match = re.search(r"\[x1plusd-module\](.*?)\[end\]", docstring, re.DOTALL)
+        if not module_block_match:
+            logger.info(f"Could not find module definition in docstring for {filepath} for module loader")
+            return config
+
+        module_block = module_block_match.group(1).strip()
+        for line in module_block.splitlines():
+            if "=" in line:
+                key, val = map(str.strip, line.split("=", 1))
+                config[key] = val
+        return config
+  
+
     async def start(self):
-        asyncio.create_task(self.mqtt.task())
         asyncio.create_task(self.settings.task())
-        asyncio.create_task(self.ota.task())
-        asyncio.create_task(self.httpd.task())
-        asyncio.create_task(self.sensors.task())
-        asyncio.create_task(self.expansion.task())
-        asyncio.create_task(self.mcproto.task())
-        asyncio.create_task(self.actions.task())
-        if self.polar_cloud:
-            asyncio.create_task(self.polar_cloud.begin())
+        
+        default_start_func = 'task'
+
+        for name, module in self.MODULES.items():
+            try: 
+                start_func = module.get('definition', {}).get('start_func', default_start_func)
+                if start_func != 'null':
+                    if not hasattr(getattr(self, name), start_func):
+                        logger.warn(f"Could not start task for x1plusd module {name}. Start function not found: {start_func}")
+                        continue
+                    asyncio.create_task(getattr(getattr(self, name), start_func)())
+            except Exception as e:
+                logger.error(f"Error starting x1plusd module {name}. {e.__class__.__name__}: {e}")
 
         logger.info("x1plusd is running")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__main__.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/__main__.py
@@ -30,12 +30,31 @@ def exceptions(loop, ctx):
 
 async def start():
     x1plusd = await X1PlusDaemon.create()
-    await x1plusd.start()
+
+    for key in x1plusd.settings_keys:
+        x1plusd.settings.on(key, lambda: stop())
+
+    await x1plusd.start() 
+
 
 # TODO: check if we are already running
 loop = asyncio.new_event_loop()
 loop.set_exception_handler(exceptions)
 loop.create_task(start())
+
+def stop():
+    asyncio.create_task(stop_loop())
+
+async def stop_loop():
+    logger.info("Stopping x1plusd after module config change")
+    await asyncio.sleep(2)
+    current_task = asyncio.current_task(loop=loop)
+    tasks = [task for task in asyncio.all_tasks(loop=loop) if task != current_task]
+    for task in tasks:
+        task.cancel()
+    await asyncio.sleep(5)
+    quit()
+
 try:
     loop.run_forever()
 finally:

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/delay.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/delay.py
@@ -1,0 +1,18 @@
+"""
+[action-type]
+name=delay
+[end]
+"""
+from ..actions import register_action
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+@register_action("delay")
+async def _action_delay(handler, subconfig):
+    logger.debug(f"delay action: {subconfig}")
+    if type(subconfig) != int and type(subconfig) != float:
+        raise TypeError(f"delay parameter {subconfig} was not numberish")
+    await asyncio.sleep(subconfig)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/file.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/file.py
@@ -1,0 +1,36 @@
+"""
+[action-type]
+name=file
+[end]
+"""
+from ..actions import register_action
+
+import logging
+import json
+import yaml
+
+logger = logging.getLogger(__name__)
+
+@register_action("file")
+async def _action_file(handler, subconfig):
+    if type(subconfig) != str:
+        raise TypeError(f"parameter {subconfig} to 'file' action was not a string")
+    if subconfig[0] != "/":
+        subconfig = f"/sdcard/{subconfig}"
+    with open(subconfig) as f:
+        contents_raw = f.read()
+    
+    contents = None
+    if contents is None:
+        try:
+            contents = json.loads(contents_raw)
+        except:
+            pass
+    if contents is None:
+        try:
+            contents = yaml.safe_load(contents_raw)
+        except:
+            pass
+    if contents is None:
+        raise ValueError(f"file {subconfig} seemed to be neither a yaml file nor a json file")
+    return await handler.execute_step(contents)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/gcode.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/gcode.py
@@ -1,0 +1,17 @@
+"""
+[action-type]
+name=gcode
+[end]
+"""
+from ..actions import register_action
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+@register_action("gcode")
+async def _action_gcode(handler, subconfig):
+    logger.debug(f"gcode action: {subconfig}")
+    if type(subconfig) != str:
+        raise TypeError(f"gcode parameter {subconfig} was not str")
+    await handler.daemon.mqtt.publish_request({ "print": { "command": "gcode_line", "sequence_id": "0", "param": subconfig } })

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/syslog.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/action_types/syslog.py
@@ -1,0 +1,14 @@
+"""
+[action-type]
+name=syslog
+[end]
+"""
+from ..actions import register_action
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+@register_action("syslog")
+async def _action_syslog(handler, subconfig):
+    logger.info(f"syslog action: {subconfig}")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
@@ -1,12 +1,4 @@
 """
-[x1plusd-module]
-name=actions
-class_name=ActionHandler
-requires_router=true
-settings_key=x1plusd.modules.actions
-default_state=true
-[end]
-
 Actions trigger mechanism
 
 Many different things on the X1 system need to take actions.  For instance,

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/actions.py
@@ -1,4 +1,12 @@
 """
+[x1plusd-module]
+name=actions
+class_name=ActionHandler
+requires_router=true
+settings_key=x1plusd.modules.actions
+default_state=true
+[end]
+
 Actions trigger mechanism
 
 Many different things on the X1 system need to take actions.  For instance,

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -1,7 +1,13 @@
+"""
+[expansion-driver]
+name=i2c
+class_name=I2cDriver
+[end]
+"""
+
 import os
 import re
 import logging
-import importlib
 
 import pyftdi.i2c
 import binascii
@@ -33,7 +39,7 @@ class I2cDriver():
                 driver_path = os.path.join(self.DRIVER_DIR, filename)
 
                 driver_data = module_docstring_parser(driver_path, "i2c-driver")
-                if not driver_data or not driver_data.get("class_name", None) or not driver_data.get("device_type", None):
+                if not driver_data or not driver_data.get("class_name", None) or not driver_data.get("name", None):
                     continue
 
                 package = "x1plus.services.x1plusd.expansion.i2c_drivers"
@@ -47,10 +53,10 @@ class I2cDriver():
 
                 try:
                     driver_class = getattr(module, driver_data.get("class_name"))
-                    self.DEVICE_DRIVERS[driver_data.get("device_type")] = driver_class
-                    logger.info(f"Loaded I2C Driver: {driver_data.get("device_type")}")
+                    self.DEVICE_DRIVERS[driver_data.get("name")] = driver_class
+                    logger.info(f"Loaded I2C Driver: {driver_data.get("name")}")
                 except Exception as e:
-                    logger.error(f"Failed to load I2C Driver '{driver_data.get("device_type")}': {e.__class__.__name__}: {e}")
+                    logger.error(f"Failed to load I2C Driver '{driver_data.get("name")}': {e.__class__.__name__}: {e}")
         
         # I2C config format is just a dict of addresses -> devices
         for address, devices in config.items():

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -1,7 +1,7 @@
 import os
+import re
 import logging
-import importlib.util
-import inspect
+import importlib
 
 import pyftdi.i2c
 import binascii
@@ -23,21 +23,26 @@ class I2cDriver():
         
         self.daemon = daemon
         self.devices = []
-        
-        self.drivers = {}
-        
+
         # Load all valid driver classes from directory
         for filename in os.listdir(self.DRIVER_DIR):
-            if filename.endswith('.py'):
+            if filename.endswith(".py") and not filename.startswith("_"):
                 module_name = filename[:-3]
                 driver_path = os.path.join(self.DRIVER_DIR, filename)
-                spec = importlib.util.spec_from_file_location(module_name, driver_path)
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-                
-                for name, driver in inspect.getmembers(module, inspect.isclass):
-                    if hasattr(driver, 'device_type'): 
-                        self.DEVICE_DRIVERS[driver.device_type] = driver
+
+                driver_data = self.driver_parser(driver_path)
+                if not driver_data or not driver_data.get("class_name", None) or not driver_data.get("device_type", None):
+                    continue
+
+                package = "x1plus.services.x1plusd.expansion.i2c_drivers"
+
+                module, module_name = self.load_module(driver_path, package)
+                if not hasattr(module, driver_data.get("class_name")):
+                    logger.warn(f"Could not load {module_name} in i2c driver loader. Class not found: {driver_data.get("class_name")}")
+                    continue
+
+                driver_class = getattr(module, driver_data.get("class_name"))
+                self.DEVICE_DRIVERS[driver_data.get("device_type")] = driver_class
         
         # I2C config format is just a dict of addresses -> devices
         for address, devices in config.items():
@@ -47,14 +52,51 @@ class I2cDriver():
                 try:
                     # Only load device with driver if requested by I2C config
                     if driver := self.DEVICE_DRIVERS.get(device, None):
-                        self.devices.append(driver(address = address, i2c_driver = self, config = subconfig, logger = logger))
+                        self.devices.append(driver(address = address, i2c_driver = self, config = subconfig))
                     else:
                         logger.error(f"failed to initialize driver for {device}@0x{address:2x} on {ftdi_path}. Compatible driver not found")
                 except Exception as e:
                     logger.error(f"failed to initialize {device}@0x{address:2x} on {ftdi_path}: {e.__class__.__name__}: {e}")
     
+
     def disconnect(self):
         logger.info("shutting down I2C")
         for d in self.devices:
             d.disconnect()
         self.i2c.close()
+
+    
+    def load_module(self, file_path, package_name):
+        module_name = os.path.splitext(os.path.basename(file_path))[0]
+        module = importlib.import_module(f"{package_name}.{module_name}")
+        return module, module_name
+
+
+    def driver_parser(self, filepath: str) -> dict:
+        content = None
+        config = {}
+        try:
+            with open(filepath, 'r') as file:
+                content = file.read()
+        except Exception as e:
+            logger.warn(f"Could not load {filepath} in i2c driver loader. {e.__class__.__name__}: {e}")
+            return config
+        
+        docstring_match = re.match(r"^([\"']{3})(.*?)\1", content, re.DOTALL)
+        if not docstring_match:
+            logger.debug(f"No docstring found for {filepath} for i2c driver loader")
+            return config
+        
+        docstring = docstring_match.group(2).strip()
+        definition_block_match = re.search(r"\[i2c-driver\](.*?)\[end\]", docstring, re.DOTALL)
+        if not definition_block_match:
+            logger.info(f"Could not find driver definition in docstring for {filepath} for i2c driver loader")
+            return config
+
+        definition_block = definition_block_match.group(1).strip()
+        for line in definition_block.splitlines():
+            if "=" in line:
+                key, val = map(str.strip, line.split("=", 1))
+                config[key] = val
+        return config
+  

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c.py
@@ -1,5 +1,7 @@
 import os
 import logging
+import importlib.util
+import inspect
 
 import pyftdi.i2c
 import binascii
@@ -11,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 class I2cDriver():
     DEVICE_DRIVERS = {}
+    DRIVER_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), './i2c_drivers')
     
     def __init__(self, daemon, config, ftdi_path, port_name):
         self.ftdi_path = ftdi_path
@@ -21,13 +24,32 @@ class I2cDriver():
         self.daemon = daemon
         self.devices = []
         
+        self.drivers = {}
+        
+        # Load all valid driver classes from directory
+        for filename in os.listdir(self.DRIVER_DIR):
+            if filename.endswith('.py'):
+                module_name = filename[:-3]
+                driver_path = os.path.join(self.DRIVER_DIR, filename)
+                spec = importlib.util.spec_from_file_location(module_name, driver_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                
+                for name, driver in inspect.getmembers(module, inspect.isclass):
+                    if hasattr(driver, 'device_type'): 
+                        self.DEVICE_DRIVERS[driver.device_type] = driver
+        
         # I2C config format is just a dict of addresses -> devices
         for address, devices in config.items():
             address = int(address, 0)
             
             for device, subconfig in devices.items():
                 try:
-                    self.devices.append(self.DEVICE_DRIVERS[device](address = address, i2c_driver = self, config = subconfig))
+                    # Only load device with driver if requested by I2C config
+                    if driver := self.DEVICE_DRIVERS.get(device, None):
+                        self.devices.append(driver(address = address, i2c_driver = self, config = subconfig, logger = logger))
+                    else:
+                        logger.error(f"failed to initialize driver for {device}@0x{address:2x} on {ftdi_path}. Compatible driver not found")
                 except Exception as e:
                     logger.error(f"failed to initialize {device}@0x{address:2x} on {ftdi_path}: {e.__class__.__name__}: {e}")
     
@@ -36,218 +58,3 @@ class I2cDriver():
         for d in self.devices:
             d.disconnect()
         self.i2c.close()
-
-class Sht41Driver():
-    CMD_SERIAL_NUMBER = 0x89
-    CMD_MEASURE_HIGH_PRECISION = 0xFD
-
-    def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.daemon.sensors
-
-        self.sht41 = i2c_driver.i2c.get_port(address)
-
-        self.sht41.write((self.CMD_SERIAL_NUMBER, ))
-        sn = self.sht41.read(readlen = 6)
-        self.sn = binascii.hexlify(sn[0:2] + sn[3:5]).decode()
-        
-        self.interval_ms = int(config.get('interval_ms', 1000))
-        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/sht41/{self.sn}")
-        
-        self.task = asyncio.create_task(self._task())
-        logger.info(f"probed SHT41 sensor at 0x{address:2x} with serial number {self.sn}")
-
-    def disconnect(self):
-        if self.task:
-            self.task.cancel()
-            self.task = None
-    
-    async def _task(self):
-        while True:
-            try:
-                self.sht41.write((self.CMD_MEASURE_HIGH_PRECISION, ))
-                da = self.sht41.read(readlen = 6)
-                t_raw = int.from_bytes(da[0:2], "big")
-                rh_raw = int.from_bytes(da[3:5], "big")
-            
-                t_C = -45 + 175 * t_raw / 65535
-                rh_pct = -6 + 125 * rh_raw/65535
-            
-                await self.sensors.publish(self.name, type = 'sht41', serial = self.sn, t_c = t_C, rh_pct = rh_pct)
-            except Exception as e:
-                await self.sensors.publish(self.name, type = 'sht41', serial = self.sn, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
-            
-            await asyncio.sleep(self.interval_ms / 1000.0)
-    
-I2cDriver.DEVICE_DRIVERS['sht41'] = Sht41Driver
-
-class Aht20Driver():
-    CMD_RESET = 0xBA
-    CMD_INITIALIZE = 0xE1
-    CMD_MEASURE = 0xAC
-
-    def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.daemon.sensors
-
-        self.aht20 = i2c_driver.i2c.get_port(address)
-
-        self.aht20.write((self.CMD_RESET, ))
-        time.sleep(0.05)
-        
-        self.aht20.write(b'\xE1\x08\x00')
-        time.sleep(0.02)
-        self.aht20.write(b'\xBE\x08\x00')
-
-        did_init = False
-        for i in range(10):
-            time.sleep(0.02)
-            rv = self.aht20.read(readlen = 1)
-            if (rv[0] & 0x88) == 0x08:
-                did_init = True
-                break
-        if not did_init:
-            raise Exception("AHT20 never calibrated")
-        
-        self.aht20.write(b'\x71')
-        
-        self.interval_ms = int(config.get('interval_ms', 1000))
-        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/aht20")
-        
-        self.task = asyncio.create_task(self._task())
-        logger.info(f"probed AHT20 sensor at 0x{address:2x}")
-
-    def disconnect(self):
-        if self.task:
-            self.task.cancel()
-            self.task = None
-    
-    async def _task(self):
-        while True:
-            try:
-                self.aht20.write(b'\xAC\x33\x00')#(self.CMD_MEASURE, 0x33, 0x00, ))
-                await asyncio.sleep(0.01)
-                
-                did_read = False
-                for i in range(10):
-                    da = self.aht20.read(readlen = 1)
-                    if da[0] & 0x80 == 0:
-                        did_read = True
-                        break
-                    await asyncio.sleep(0.01)
-                if not did_read:
-                    raise Exception("AHT20 did not finish measuring")
-
-                da = self.aht20.read(readlen = 6)
-                
-                rh_raw = (da[1] << 12) | (da[2] << 4) | (da[3] >> 4)
-                rh_pct = (rh_raw * 100) / 0x100000
-                
-                t_raw = ((da[3] & 0xF) << 16) | (da[4] << 8) | da[5]
-                t_C = ((t_raw * 200.0) / 0x100000) - 50                
-
-                await self.sensors.publish(self.name, type = 'aht20', t_c = t_C, rh_pct = rh_pct)
-            except Exception as e:
-                await self.sensors.publish(self.name, type = 'aht20', inop = { 'exception': f"{e.__class__.__name__}: {e}" })
-            
-            await asyncio.sleep(self.interval_ms / 1000.0)
-    
-I2cDriver.DEVICE_DRIVERS['aht20'] = Aht20Driver
-
-class Pmsa003iDriver():
-
-    device_type = 'pmsa003i'
-    
-    def __init__(self, address, i2c_driver, config):
-        self.sensors = i2c_driver.daemon.sensors
-
-        self.pmsa003i = i2c_driver.i2c.get_port(address)
-        
-        self.interval_ms = int(config.get('interval_ms', 1000))
-        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
-        self.overflow_mitigation = config.get('overflow_mitigation', False)
-        
-        
-        self.task = asyncio.create_task(self._task())
-        logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
-
-    def disconnect(self):
-        if self.task:
-            self.task.cancel()
-            self.task = None
-    
-   
-    async def _task(self):
-        while True:
-            try:
-            
-                did_read = False
-                da = None
-                for i in range(20):
-                    da = self.pmsa003i.read(readlen = 32)
-                    if da[0] == 0x42 and da[1] == 0x4D:
-                        did_read = True
-                        break
-                    await asyncio.sleep(0.01)
-                if not did_read or da is None:
-                    raise Exception(f"{self.device_type.upper()} did not finish measuring")
-
-                # Standard Concentration µg/m^3
-                pm1_0_ugm3_std = (da[4] << 8) | da[5]
-                pm2_5_ugm3_std = (da[6] << 8) | da[7]
-                pm10_ugm3_std = (da[8] << 8) | da[9]
-                
-                # Environmental Concentration µg/m^3 - Useful
-                pm1_0_ugm3_env = (da[10] << 8) | da[11]
-                pm2_5_ugm3_env = (da[12] << 8) | da[13]
-                pm10_ugm3_env = (da[14] << 8) | da[15]
-                
-                # Particles Greater Than <particle_size>μm / 0.1L air
-                pm0_3_conc = (da[16] << 8) | da[17]
-                pm0_5_conc = (da[18] << 8) | da[19]
-                pm1_0_conc = (da[20] << 8) | da[21]
-                pm2_5_conc = (da[22] << 8) | da[23]
-                pm5_0_conc = (da[24] << 8) | da[25]
-                pm10_conc = (da[26] << 8) | da[27]
-                
-                # Overflow mitigation from 16bit limit
-                if pm5_0_conc < pm10_conc:
-                    if self.overflow_mitigation:
-                        pm5_0_conc += 65535
-                    else: 
-                        pm5_0_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 5.0 Concentation is out of range (>65535)")
-                if pm2_5_conc < pm5_0_conc:
-                    if self.overflow_mitigation:
-                        pm2_5_conc += 65535
-                    else: 
-                        pm2_5_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 2.5 Concentation is out of range (>65535)")
-                if pm1_0_conc < pm2_5_conc:
-                    if self.overflow_mitigation:
-                        pm1_0_conc += 65535
-                    else: 
-                        pm1_0_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 1.0 Concentation is out of range (>65535)")
-                if pm0_5_conc < pm1_0_conc:
-                    if self.overflow_mitigation:
-                        pm0_5_conc += 65535
-                    else: 
-                        pm0_5_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.5 Concentation is out of range (>65535)")
-                if pm0_3_conc < pm0_5_conc:
-                    if self.overflow_mitigation:
-                        pm0_3_conc += 65535
-                    else: 
-                        pm0_3_conc = -1
-                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.3 Concentation is out of range (>65535)")
-
-                await self.sensors.publish(self.name, type = self.device_type,
-                    pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,
-                    pm1_0_ugm3 = pm1_0_ugm3_env, pm2_5_ugm3 = pm2_5_ugm3_env, pm10_ugm3 = pm10_ugm3_env, 
-                    pm0_3_conc = pm0_3_conc, pm0_5_conc = pm0_5_conc, pm1_0_conc = pm1_0_conc, 
-                    pm2_5_conc = pm2_5_conc, pm5_0_conc = pm5_0_conc, pm10_conc = pm10_conc, overflow_mitigation=self.overflow_mitigation)
-            except Exception as e:
-                await self.sensors.publish(self.name, type = self.device_type, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
-            
-            await asyncio.sleep(self.interval_ms / 1000.0)
-
-I2cDriver.DEVICE_DRIVERS[Pmsa003iDriver.device_type] = Pmsa003iDriver

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
@@ -1,0 +1,75 @@
+import asyncio
+import time
+
+class Aht20Driver():
+    CMD_RESET = 0xBA
+    CMD_INITIALIZE = 0xE1
+    CMD_MEASURE = 0xAC
+    
+    device_type = 'aht20'
+
+    def __init__(self, address, i2c_driver, config, logger):
+        self.logger = logger
+        self.sensors = i2c_driver.daemon.sensors
+
+        self.aht20 = i2c_driver.i2c.get_port(address)
+
+        self.aht20.write((self.CMD_RESET, ))
+        time.sleep(0.05)
+        
+        self.aht20.write(b'\xE1\x08\x00')
+        time.sleep(0.02)
+        self.aht20.write(b'\xBE\x08\x00')
+
+        did_init = False
+        for i in range(10):
+            time.sleep(0.02)
+            rv = self.aht20.read(readlen = 1)
+            if (rv[0] & 0x88) == 0x08:
+                did_init = True
+                break
+        if not did_init:
+            raise Exception(f"{self.device_type.upper()} never calibrated")
+        
+        self.aht20.write(b'\x71')
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
+        
+        self.task = asyncio.create_task(self._task())
+        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+    async def _task(self):
+        while True:
+            try:
+                self.aht20.write(b'\xAC\x33\x00')#(self.CMD_MEASURE, 0x33, 0x00, ))
+                await asyncio.sleep(0.01)
+                
+                did_read = False
+                for i in range(10):
+                    da = self.aht20.read(readlen = 1)
+                    if da[0] & 0x80 == 0:
+                        did_read = True
+                        break
+                    await asyncio.sleep(0.01)
+                if not did_read:
+                    raise Exception(f"{self.device_type.upper()} did not finish measuring")
+
+                da = self.aht20.read(readlen = 6)
+                
+                rh_raw = (da[1] << 12) | (da[2] << 4) | (da[3] >> 4)
+                rh_pct = (rh_raw * 100) / 0x100000
+                
+                t_raw = ((da[3] & 0xF) << 16) | (da[4] << 8) | da[5]
+                t_C = ((t_raw * 200.0) / 0x100000) - 50                
+
+                await self.sensors.publish(self.name, type = self.device_type, t_c = t_C, rh_pct = rh_pct)
+            except Exception as e:
+                await self.sensors.publish(self.name, type = self.device_type, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
@@ -1,5 +1,15 @@
+"""
+[i2c-driver]
+device_type=aht20
+class_name=Aht20Driver
+[end]
+"""
+
+import logging
 import asyncio
 import time
+
+logger = logging.getLogger(__name__)
 
 class Aht20Driver():
     CMD_RESET = 0xBA
@@ -8,8 +18,7 @@ class Aht20Driver():
     
     device_type = 'aht20'
 
-    def __init__(self, address, i2c_driver, config, logger):
-        self.logger = logger
+    def __init__(self, address, i2c_driver, config):
         self.sensors = i2c_driver.daemon.sensors
 
         self.aht20 = i2c_driver.i2c.get_port(address)
@@ -37,7 +46,7 @@ class Aht20Driver():
         self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
         
         self.task = asyncio.create_task(self._task())
-        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
+        logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
 
     def disconnect(self):
         if self.task:

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/aht20_driver.py
@@ -1,6 +1,6 @@
 """
 [i2c-driver]
-device_type=aht20
+name=aht20
 class_name=Aht20Driver
 [end]
 """

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
@@ -1,0 +1,101 @@
+import asyncio
+import time
+
+class Pmsa003iDriver():
+
+    device_type = 'pmsa003i'
+    
+    def __init__(self, address, i2c_driver, config, logger):
+        self.logger = logger
+        self.sensors = i2c_driver.daemon.sensors
+
+        self.pmsa003i = i2c_driver.i2c.get_port(address)
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}")
+        self.overflow_mitigation = config.get('overflow_mitigation', False)
+        
+        
+        self.task = asyncio.create_task(self._task())
+        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+   
+    async def _task(self):
+        while True:
+            try:
+            
+                did_read = False
+                da = None
+                for i in range(20):
+                    da = self.pmsa003i.read(readlen = 32)
+                    if da[0] == 0x42 and da[1] == 0x4D:
+                        did_read = True
+                        break
+                    await asyncio.sleep(0.01)
+                if not did_read or da is None:
+                    raise Exception(f"{self.device_type.upper()} did not finish measuring")
+
+                # Standard Concentration µg/m^3
+                pm1_0_ugm3_std = (da[4] << 8) | da[5]
+                pm2_5_ugm3_std = (da[6] << 8) | da[7]
+                pm10_ugm3_std = (da[8] << 8) | da[9]
+                
+                # Environmental Concentration µg/m^3 - Useful
+                pm1_0_ugm3_env = (da[10] << 8) | da[11]
+                pm2_5_ugm3_env = (da[12] << 8) | da[13]
+                pm10_ugm3_env = (da[14] << 8) | da[15]
+                
+                # Particles Greater Than <particle_size>μm / 0.1L air
+                pm0_3_conc = (da[16] << 8) | da[17]
+                pm0_5_conc = (da[18] << 8) | da[19]
+                pm1_0_conc = (da[20] << 8) | da[21]
+                pm2_5_conc = (da[22] << 8) | da[23]
+                pm5_0_conc = (da[24] << 8) | da[25]
+                pm10_conc = (da[26] << 8) | da[27]
+                
+                # Overflow mitigation from 16bit limit
+                if pm5_0_conc < pm10_conc:
+                    if self.overflow_mitigation:
+                        pm5_0_conc += 65535
+                    else: 
+                        pm5_0_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 5.0 Concentation is out of range (>65535)")
+                if pm2_5_conc < pm5_0_conc:
+                    if self.overflow_mitigation:
+                        pm2_5_conc += 65535
+                    else: 
+                        pm2_5_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 2.5 Concentation is out of range (>65535)")
+                if pm1_0_conc < pm2_5_conc:
+                    if self.overflow_mitigation:
+                        pm1_0_conc += 65535
+                    else: 
+                        pm1_0_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 1.0 Concentation is out of range (>65535)")
+                if pm0_5_conc < pm1_0_conc:
+                    if self.overflow_mitigation:
+                        pm0_5_conc += 65535
+                    else: 
+                        pm0_5_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.5 Concentation is out of range (>65535)")
+                if pm0_3_conc < pm0_5_conc:
+                    if self.overflow_mitigation:
+                        pm0_3_conc += 65535
+                    else: 
+                        pm0_3_conc = -1
+                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.3 Concentation is out of range (>65535)")
+
+                await self.sensors.publish(self.name, type = self.device_type,
+                    pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,
+                    pm1_0_ugm3 = pm1_0_ugm3_env, pm2_5_ugm3 = pm2_5_ugm3_env, pm10_ugm3 = pm10_ugm3_env, 
+                    pm0_3_conc = pm0_3_conc, pm0_5_conc = pm0_5_conc, pm1_0_conc = pm1_0_conc, 
+                    pm2_5_conc = pm2_5_conc, pm5_0_conc = pm5_0_conc, pm10_conc = pm10_conc, overflow_mitigation=self.overflow_mitigation)
+            except Exception as e:
+                await self.sensors.publish(self.name, type = self.device_type, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
@@ -1,12 +1,20 @@
+"""
+[i2c-driver]
+device_type=pmsa003i
+class_name=Pmsa003iDriver
+[end]
+"""
+import logging
 import asyncio
 import time
+
+logger = logging.getLogger(__name__)
 
 class Pmsa003iDriver():
 
     device_type = 'pmsa003i'
     
-    def __init__(self, address, i2c_driver, config, logger):
-        self.logger = logger
+    def __init__(self, address, i2c_driver, config):
         self.sensors = i2c_driver.daemon.sensors
 
         self.pmsa003i = i2c_driver.i2c.get_port(address)
@@ -17,7 +25,7 @@ class Pmsa003iDriver():
         
         
         self.task = asyncio.create_task(self._task())
-        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
+        logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x}")
 
     def disconnect(self):
         if self.task:
@@ -64,31 +72,31 @@ class Pmsa003iDriver():
                         pm5_0_conc += 65535
                     else: 
                         pm5_0_conc = -1
-                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 5.0 Concentation is out of range (>65535)")
+                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 5.0 Concentation is out of range (>65535)")
                 if pm2_5_conc < pm5_0_conc:
                     if self.overflow_mitigation:
                         pm2_5_conc += 65535
                     else: 
                         pm2_5_conc = -1
-                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 2.5 Concentation is out of range (>65535)")
+                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 2.5 Concentation is out of range (>65535)")
                 if pm1_0_conc < pm2_5_conc:
                     if self.overflow_mitigation:
                         pm1_0_conc += 65535
                     else: 
                         pm1_0_conc = -1
-                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 1.0 Concentation is out of range (>65535)")
+                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 1.0 Concentation is out of range (>65535)")
                 if pm0_5_conc < pm1_0_conc:
                     if self.overflow_mitigation:
                         pm0_5_conc += 65535
                     else: 
                         pm0_5_conc = -1
-                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.5 Concentation is out of range (>65535)")
+                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.5 Concentation is out of range (>65535)")
                 if pm0_3_conc < pm0_5_conc:
                     if self.overflow_mitigation:
                         pm0_3_conc += 65535
                     else: 
                         pm0_3_conc = -1
-                        self.logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.3 Concentation is out of range (>65535)")
+                        logger.info(f"{self.device_type.upper()} {self.name} value for PM > 0.3 Concentation is out of range (>65535)")
 
                 await self.sensors.publish(self.name, type = self.device_type,
                     pm1_0_ugm3_std = pm1_0_ugm3_std, pm2_5_ugm3_std = pm2_5_ugm3_std, pm10_ugm3_std = pm10_ugm3_std,

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/pmsa003i_driver.py
@@ -1,6 +1,6 @@
 """
 [i2c-driver]
-device_type=pmsa003i
+name=pmsa003i
 class_name=Pmsa003iDriver
 [end]
 """

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
@@ -1,6 +1,6 @@
 """
 [i2c-driver]
-device_type=sht41
+name=sht41
 class_name=Sht41Driver
 [end]
 """

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
@@ -1,7 +1,16 @@
+"""
+[i2c-driver]
+device_type=sht41
+class_name=Sht41Driver
+[end]
+"""
 import binascii
 
+import logging
 import asyncio
 import time
+
+logger = logging.getLogger(__name__)
 
 class Sht41Driver():
     CMD_SERIAL_NUMBER = 0x89
@@ -9,8 +18,7 @@ class Sht41Driver():
     
     device_type = 'sht41'
 
-    def __init__(self, address, i2c_driver, config, logger):
-        self.logger = logger
+    def __init__(self, address, i2c_driver, config):
         self.sensors = i2c_driver.daemon.sensors
 
         self.sht41 = i2c_driver.i2c.get_port(address)
@@ -23,7 +31,7 @@ class Sht41Driver():
         self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}/{self.sn}")
         
         self.task = asyncio.create_task(self._task())
-        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x} with serial number {self.sn}")
+        logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x} with serial number {self.sn}")
 
     def disconnect(self):
         if self.task:

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/i2c_drivers/sht41_driver.py
@@ -1,0 +1,48 @@
+import binascii
+
+import asyncio
+import time
+
+class Sht41Driver():
+    CMD_SERIAL_NUMBER = 0x89
+    CMD_MEASURE_HIGH_PRECISION = 0xFD
+    
+    device_type = 'sht41'
+
+    def __init__(self, address, i2c_driver, config, logger):
+        self.logger = logger
+        self.sensors = i2c_driver.daemon.sensors
+
+        self.sht41 = i2c_driver.i2c.get_port(address)
+
+        self.sht41.write((self.CMD_SERIAL_NUMBER, ))
+        sn = self.sht41.read(readlen = 6)
+        self.sn = binascii.hexlify(sn[0:2] + sn[3:5]).decode()
+        
+        self.interval_ms = int(config.get('interval_ms', 1000))
+        self.name = config.get('name', f"{i2c_driver.ftdi_path}/i2c/0x{address:02x}/{self.device_type}/{self.sn}")
+        
+        self.task = asyncio.create_task(self._task())
+        self.logger.info(f"probed {self.device_type.upper()} sensor at 0x{address:2x} with serial number {self.sn}")
+
+    def disconnect(self):
+        if self.task:
+            self.task.cancel()
+            self.task = None
+    
+    async def _task(self):
+        while True:
+            try:
+                self.sht41.write((self.CMD_MEASURE_HIGH_PRECISION, ))
+                da = self.sht41.read(readlen = 6)
+                t_raw = int.from_bytes(da[0:2], "big")
+                rh_raw = int.from_bytes(da[3:5], "big")
+            
+                t_C = -45 + 175 * t_raw / 65535
+                rh_pct = -6 + 125 * rh_raw/65535
+            
+                await self.sensors.publish(self.name, type = self.device_type, serial = self.sn, t_c = t_C, rh_pct = rh_pct)
+            except Exception as e:
+                await self.sensors.publish(self.name, type = self.device_type, serial = self.sn, inop = { 'exception': f"{e.__class__.__name__}: {e}" })
+            
+            await asyncio.sleep(self.interval_ms / 1000.0)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -3,6 +3,7 @@ import logging
 import asyncio
 import time
 import struct
+from x1plus.utils import module_loader, module_docstring_parser
 
 from collections import namedtuple
 
@@ -72,18 +73,50 @@ class LedStripDriver():
         #
         #   [ 'paused', { 'rainbow': { 'brightness': 0.5 } } ]
         self.anim_list = []
+        self.load_anim_classes()
         for anim in self.config.get('animations', self.DEFAULT_ANIMATIONS):
-            if type(anim) == str:
+            if type(anim) == str and self.ANIMATIONS.get(anim, None):
                 self.anim_list.append(self.ANIMATIONS[anim](self, {}))
                 continue
             elif type(anim) != dict or len(anim) != 1:
                 raise ValueError("animation must be either string or dictionary with exactly one key")
             
             (animname, subconfig) = next(iter(anim.items()))
-            self.anim_list.append(self.ANIMATIONS[animname](self, subconfig))
+            if self.ANIMATIONS.get(animname, None):
+                self.anim_list.append(self.ANIMATIONS[animname](self, subconfig))
 
         self.last_gcode_state = None
         self.anim_watcher = asyncio.create_task(self.anim_watcher_task())
+
+    def load_anim_classes(self):
+        animation_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "./ledstrip_animations")
+
+        # Load all valid driver classes from directory
+        for filename in os.listdir(animation_dir):
+            if filename.endswith(".py") and not filename.startswith("_"):
+                module_name = filename[:-3]
+                anim_path = os.path.join(animation_dir, filename)
+
+                anim_data = module_docstring_parser(anim_path, "led-animation")
+                if not anim_data or not anim_data.get("class_name", None) or not anim_data.get("name", None):
+                    continue
+
+                package = "x1plus.services.x1plusd.expansion.ledstrip_animations"
+
+                module, module_name = module_loader(anim_path, package)
+                if not module:
+                    continue
+                if not hasattr(module, anim_data.get("class_name")):
+                    logger.warn(f"Could not load {module_name} in led animation loader. Class not found: {anim_data.get('class_name')}")
+                    continue
+
+                try:
+                    driver_class = getattr(module, anim_data.get("class_name"))
+                    self.ANIMATIONS[anim_data.get("name")] = driver_class
+                    logger.info(f"Loaded LedStrip Animation: {anim_data.get('name')}")
+                except Exception as e:
+                    logger.error(f"Failed to load LedStrip Animation '{anim_data.get("name")}': {e.__class__.__name__}: {e}")
+
 
     def update_gpio(self):
         self.ftdi.write_data(bytes([Ftdi.SET_BITS_LOW, self.gpio_out, self.gpio_dir]))
@@ -188,157 +221,3 @@ class LedStripGpio(Gpio):
             self.ledstrip.gpio_last_read_data = data
         inverted = self.attr.get('inverted', False)
         return ((data[0] & self.pin) == self.pin) ^ inverted
-
-###############
-
-import colorsys
-import math
-
-class RainbowAnimation():
-    def __init__(self, leds, config):
-        self.leds = leds
-        self.brightness = config.get('brightness', 0.3)
-    
-    def can_render(self):
-        return True 
-    
-    async def task(self):
-        ph = 0
-        while True:
-            ph = ph + 0.01
-            arr = []
-            for i in range(self.leds.n_leds):
-                arr += colorsys.hsv_to_rgb((ph + i * 0.05) % 1, 1.0, 1.0)
-            self.leds.put([int(a * self.brightness * 255) for a in arr])
-            if ph > 1:
-                ph -= 1
-            await asyncio.sleep(0.05)
-        
-LedStripDriver.ANIMATIONS['rainbow'] = RainbowAnimation
-
-
-class PausedAnimation():
-    def __init__(self, leds, config):
-        self.leds = leds
-        self.brightness = config.get('brightness', 0.25)
-    
-    def can_render(self):
-        return self.leds.last_gcode_state == 'PAUSE'
-    
-    async def task(self):
-        BLINK_PATTERN = [(160, 250), (140, 700), (160, 250), (140, 700), (160, 250), (140, 3000)]
-        while True:
-            for on,off in BLINK_PATTERN:
-                arr = []
-                for i in range(self.leds.n_leds):
-                    arr += (self.brightness * 0.7, self.brightness * 1.0, 0.0,)
-                self.leds.put([int(a * 255) for a in arr])
-                await asyncio.sleep(on / 1000.0)
-                
-                self.leds.put(b'\x00\x00\x00' * self.leds.n_leds)
-                await asyncio.sleep(off / 1000.0)
-        
-LedStripDriver.ANIMATIONS['paused'] = PausedAnimation
-
-
-class FailedAnimation():
-    def __init__(self, leds, config):
-        self.leds = leds
-        self.brightness = config.get('brightness', 0.25)
-        self.timeout = config.get('timeout', 120) # failure goes away after 2 minutes
-        self.last_failed_trn = 0
-        self.last_was_failed = False
-    
-    def can_render(self):
-        failed = self.leds.last_gcode_state == 'FAILED'
-        if not self.last_was_failed and failed:
-            self.last_failed_trn = time.time()
-        self.last_was_failed = failed
-        return failed and (time.time() - self.last_failed_trn) < self.timeout
-    
-    async def task(self):
-        BLINK_PATTERN = [(750, 350), (750, 350), (750, 3000)]
-        while True:
-            for on,off in BLINK_PATTERN:
-                arr = []
-                for i in range(self.leds.n_leds):
-                    arr += (0.0, self.brightness * 1.0, 0.0,)
-                self.leds.put([int(a * 255) for a in arr])
-                await asyncio.sleep(on / 1000.0)
-                
-                arr = []
-                for i in range(self.leds.n_leds):
-                    arr += (0.0, 1/255, 0.0,)
-                self.leds.put([int(a * 255) for a in arr])
-                await asyncio.sleep(off / 1000.0)
-        
-LedStripDriver.ANIMATIONS['failed'] = FailedAnimation
-
-
-class FinishAnimation():
-    def __init__(self, leds, config):
-        self.leds = leds
-        self.brightness = config.get('brightness', 0.4)
-        self.timeout = config.get('timeout', 600) # success goes away after 10 minutes
-        self.last_finish_trn = 0
-        self.last_was_finish = False
-    
-    def can_render(self):
-        finish = self.leds.last_gcode_state == 'FINISH'
-        if not self.last_was_finish and finish:
-            self.last_finish_trn = time.time()
-        self.last_was_finish = finish
-        return finish and (time.time() - self.last_finish_trn) < self.timeout
-    
-    async def task(self):
-        ph = 0
-
-        while True:
-            ph += 0.05
-            br = 0.6 + math.sin(ph) * 0.4
-            self.leds.put([int(255 * br * self.brightness), 0, 0] * self.leds.n_leds)
-            await asyncio.sleep(0.05)
-        
-LedStripDriver.ANIMATIONS['finish'] = FinishAnimation
-
-
-class RunningAnimation():
-    def __init__(self, leds, config):
-        self.leds = leds
-        self.brightness = config.get('brightness', 0.4)
-        self.testmode = config.get('testmode', False)
-    
-    def can_render(self):
-        return self.testmode or self.leds.last_gcode_state == 'RUNNING'
-    
-    async def task(self):
-        ph = 0
-
-        def put_print_progress(pct):
-            nonlocal ph
-
-            ph += 0.15
-            pct += math.sin(ph) / (self.leds.n_leds * 6)
-
-            npct = pct * self.leds.n_leds
-            arr = []
-            for i in range(self.leds.n_leds):
-                if i == math.floor(npct):
-                    arr += [self.brightness * (npct - i), 0, 1/255]
-                elif i < npct:
-                    arr += [self.brightness, 0, 1/255]
-                else:
-                    arr += [0, 0, 1/255]
-            self.leds.put([int(a * 255) for a in arr])
-    
-        if self.testmode:
-            for i in range(501):
-                pct = i/500
-                put_print_progress(pct)
-                await asyncio.sleep(0.05)
-        else:
-            while True:
-                put_print_progress(self.leds.daemon.mqtt.latest_print_status.get('mc_percent', 0) / 100)
-                await asyncio.sleep(0.05)
-        
-LedStripDriver.ANIMATIONS['running'] = RunningAnimation

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip.py
@@ -1,3 +1,9 @@
+"""
+[expansion-driver]
+name=ledstrip
+class_name=LedStripDriver
+[end]
+"""
 import os
 import logging
 import asyncio

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/failed.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/failed.py
@@ -1,0 +1,39 @@
+"""
+[led-animation]
+name=failed
+class_name=FailedAnimation
+[end]
+"""
+import asyncio
+import time
+
+class FailedAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.25)
+        self.timeout = config.get('timeout', 120) # failure goes away after 2 minutes
+        self.last_failed_trn = 0
+        self.last_was_failed = False
+    
+    def can_render(self):
+        failed = self.leds.last_gcode_state == 'FAILED'
+        if not self.last_was_failed and failed:
+            self.last_failed_trn = time.time()
+        self.last_was_failed = failed
+        return failed and (time.time() - self.last_failed_trn) < self.timeout
+    
+    async def task(self):
+        BLINK_PATTERN = [(750, 350), (750, 350), (750, 3000)]
+        while True:
+            for on,off in BLINK_PATTERN:
+                arr = []
+                for i in range(self.leds.n_leds):
+                    arr += (0.0, self.brightness * 1.0, 0.0,)
+                self.leds.put([int(a * 255) for a in arr])
+                await asyncio.sleep(on / 1000.0)
+                
+                arr = []
+                for i in range(self.leds.n_leds):
+                    arr += (0.0, 1/255, 0.0,)
+                self.leds.put([int(a * 255) for a in arr])
+                await asyncio.sleep(off / 1000.0)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/finish.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/finish.py
@@ -1,0 +1,33 @@
+"""
+[led-animation]
+name=finish
+class_name=FinishAnimation
+[end]
+"""
+import asyncio
+import time
+import math
+
+class FinishAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.4)
+        self.timeout = config.get('timeout', 600) # success goes away after 10 minutes
+        self.last_finish_trn = 0
+        self.last_was_finish = False
+    
+    def can_render(self):
+        finish = self.leds.last_gcode_state == 'FINISH'
+        if not self.last_was_finish and finish:
+            self.last_finish_trn = time.time()
+        self.last_was_finish = finish
+        return finish and (time.time() - self.last_finish_trn) < self.timeout
+    
+    async def task(self):
+        ph = 0
+
+        while True:
+            ph += 0.05
+            br = 0.6 + math.sin(ph) * 0.4
+            self.leds.put([int(255 * br * self.brightness), 0, 0] * self.leds.n_leds)
+            await asyncio.sleep(0.05)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/paused.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/paused.py
@@ -1,0 +1,28 @@
+"""
+[led-animation]
+name=paused
+class_name=PausedAnimation
+[end]
+"""
+import asyncio
+
+class PausedAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.25)
+    
+    def can_render(self):
+        return self.leds.last_gcode_state == 'PAUSE'
+    
+    async def task(self):
+        BLINK_PATTERN = [(160, 250), (140, 700), (160, 250), (140, 700), (160, 250), (140, 3000)]
+        while True:
+            for on,off in BLINK_PATTERN:
+                arr = []
+                for i in range(self.leds.n_leds):
+                    arr += (self.brightness * 0.7, self.brightness * 1.0, 0.0,)
+                self.leds.put([int(a * 255) for a in arr])
+                await asyncio.sleep(on / 1000.0)
+                
+                self.leds.put(b'\x00\x00\x00' * self.leds.n_leds)
+                await asyncio.sleep(off / 1000.0)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/rainbow.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/rainbow.py
@@ -1,0 +1,28 @@
+"""
+[led-animation]
+name=rainbow
+class_name=RainbowAnimation
+[end]
+"""
+import asyncio
+import colorsys
+
+class RainbowAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.3)
+    
+    def can_render(self):
+        return True 
+    
+    async def task(self):
+        ph = 0
+        while True:
+            ph = ph + 0.01
+            arr = []
+            for i in range(self.leds.n_leds):
+                arr += colorsys.hsv_to_rgb((ph + i * 0.05) % 1, 1.0, 1.0)
+            self.leds.put([int(a * self.brightness * 255) for a in arr])
+            if ph > 1:
+                ph -= 1
+            await asyncio.sleep(0.05)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/running.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/ledstrip_animations/running.py
@@ -1,0 +1,47 @@
+"""
+[led-animation]
+name=running
+class_name=RunningAnimation
+[end]
+"""
+import asyncio
+import math
+
+class RunningAnimation():
+    def __init__(self, leds, config):
+        self.leds = leds
+        self.brightness = config.get('brightness', 0.4)
+        self.testmode = config.get('testmode', False)
+    
+    def can_render(self):
+        return self.testmode or self.leds.last_gcode_state == 'RUNNING'
+    
+    async def task(self):
+        ph = 0
+
+        def put_print_progress(pct):
+            nonlocal ph
+
+            ph += 0.15
+            pct += math.sin(ph) / (self.leds.n_leds * 6)
+
+            npct = pct * self.leds.n_leds
+            arr = []
+            for i in range(self.leds.n_leds):
+                if i == math.floor(npct):
+                    arr += [self.brightness * (npct - i), 0, 1/255]
+                elif i < npct:
+                    arr += [self.brightness, 0, 1/255]
+                else:
+                    arr += [0, 0, 1/255]
+            self.leds.put([int(a * 255) for a in arr])
+    
+        if self.testmode:
+            for i in range(501):
+                pct = i/500
+                put_print_progress(pct)
+                await asyncio.sleep(0.05)
+        else:
+            while True:
+                put_print_progress(self.leds.daemon.mqtt.latest_print_status.get('mc_percent', 0) / 100)
+                await asyncio.sleep(0.05)

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
@@ -1,3 +1,13 @@
+"""
+[x1plusd-module]
+name=expansion
+class_name=ExpansionManager
+requires_router=true
+settings_key=x1plusd.modules.expansion
+required_modules=sensors
+default_state=true
+[end]
+"""
 import asyncio
 from collections import namedtuple
 import os

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/expansion/manager.py
@@ -1,13 +1,3 @@
-"""
-[x1plusd-module]
-name=expansion
-class_name=ExpansionManager
-requires_router=true
-settings_key=x1plusd.modules.expansion
-required_modules=sensors
-default_state=true
-[end]
-"""
 import asyncio
 from collections import namedtuple
 import os
@@ -128,6 +118,7 @@ class ExpansionManager(X1PlusDBusService):
         )
 
     def load_drivers(self):
+        # Same path as self
         DRIVER_DIR = os.path.dirname(os.path.abspath(__file__))
 
          # Load all valid driver classes from directory

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
@@ -1,14 +1,3 @@
-"""
-[x1plusd-module]
-name=gpios
-class_name=GpioManager
-requires_router=false
-settings_key=x1plusd.modules.gpios
-required_modules=expansion,actions
-default_state=true
-start_func=null
-[end]
-"""
 from abc import ABC, abstractmethod
 import asyncio
 import contextlib

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/gpios.py
@@ -1,3 +1,14 @@
+"""
+[x1plusd-module]
+name=gpios
+class_name=GpioManager
+requires_router=false
+settings_key=x1plusd.modules.gpios
+required_modules=expansion,actions
+default_state=true
+start_func=null
+[end]
+"""
 from abc import ABC, abstractmethod
 import asyncio
 import contextlib
@@ -262,6 +273,8 @@ class GpioManager:
             return
         
         async def _action_worker():
+            if not hasattr(self.daemon, 'actions'):
+                return
             with contextlib.ExitStack() as stack:
                 action_queue = asyncio.Queue()
                 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
@@ -1,3 +1,13 @@
+"""
+[x1plusd-module]
+name=httpd
+class_name=HTTPService
+requires_router=true
+settings_key=x1plusd.modules.httpd
+required_modules=mqtt
+default_state=true
+[end]
+"""
 import os
 import subprocess
 import asyncio

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/httpd.py
@@ -1,13 +1,3 @@
-"""
-[x1plusd-module]
-name=httpd
-class_name=HTTPService
-requires_router=true
-settings_key=x1plusd.modules.httpd
-required_modules=mqtt
-default_state=true
-[end]
-"""
 import os
 import subprocess
 import asyncio

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mcproto.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mcproto.py
@@ -1,3 +1,12 @@
+"""
+[x1plusd-module]
+name=mcproto
+class_name=MCProtoParser
+requires_router=false
+settings_key=x1plusd.modules.mcproto
+default_state=true
+[end]
+"""
 import re
 import json
 import asyncio
@@ -261,6 +270,9 @@ class MCProtoParser():
         """
         Trigger an action to execute in the background, with only one MC protocol action allowed to run at a time.
         """
+        if not hasattr(self.daemon, 'actions'):
+            return
+
         if self.active_action:
             if not self.active_action.done():
                 logger.warning("new mcproto action being triggered, but the previous action is not complete; canceling it!")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mcproto.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mcproto.py
@@ -1,12 +1,3 @@
-"""
-[x1plusd-module]
-name=mcproto
-class_name=MCProtoParser
-requires_router=false
-settings_key=x1plusd.modules.mcproto
-default_state=true
-[end]
-"""
 import re
 import json
 import asyncio

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -1,3 +1,12 @@
+"""
+[x1plusd-module]
+name=mqtt
+class_name=MQTTClient
+requires_router=false
+settings_key=x1plusd.modules.mqtt
+default_state=true
+[end]
+"""
 import os
 import aiomqtt
 import asyncio

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -1,12 +1,3 @@
-"""
-[x1plusd-module]
-name=mqtt
-class_name=MQTTClient
-requires_router=false
-settings_key=x1plusd.modules.mqtt
-default_state=true
-[end]
-"""
 import os
 import aiomqtt
 import asyncio

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
@@ -1,3 +1,12 @@
+"""
+[x1plusd-module]
+name=ota
+class_name=OTAService
+requires_router=true
+settings_key=x1plusd.modules.ota
+default_state=true
+[end]
+"""
 import os
 import json
 import ssl

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/ota.py
@@ -1,12 +1,3 @@
-"""
-[x1plusd-module]
-name=ota
-class_name=OTAService
-requires_router=true
-settings_key=x1plusd.modules.ota
-default_state=true
-[end]
-"""
 import os
 import json
 import ssl

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
@@ -3,9 +3,7 @@
 name=polar_cloud
 class_name=PolarPrintService
 requires_router=false
-settings_key=polar_cloud
 start_func=begin
-default_state=false
 [end]
 
 Module to allow printing using Polar Cloud service.
@@ -48,16 +46,21 @@ class PolarPrintService:
 
     async def begin(self):
         """Create Socket.IO client and connect to server."""
-        self.socket = socketio.AsyncClient()
-        self.set_interface()
-        await self.get_creds()
-        await self.socket.connect(self.server_url, transports=["websocket"])
-        # Assign socket callbacks.
-        self.socket.on("registerResponse", self._on_register_response)
-        self.socket.on("keyPair", self._on_keypair_response)
-        self.socket.on("helloResponse", self._on_hello_response)
-        self.socket.on("welcome", self._on_welcome)
-        self.socket.on("delete", self._on_delete)
+        try: 
+            self.socket = socketio.AsyncClient()
+            self.set_interface()
+            await self.get_creds()
+            await self.socket.connect(self.server_url, transports=["websocket"])
+            # Assign socket callbacks.
+            self.socket.on("registerResponse", self._on_register_response)
+            self.socket.on("keyPair", self._on_keypair_response)
+            self.socket.on("helloResponse", self._on_hello_response)
+            self.socket.on("welcome", self._on_welcome)
+            self.socket.on("delete", self._on_delete)
+        except Exception as e:
+            logger.error(f"Failed to start polar_cloud: {e.__class__.__name__}: {e}")
+            if self.socket:
+                self.socket.disconnect()
 
 
     async def _on_welcome(self, response, *args, **kwargs):

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
@@ -1,4 +1,13 @@
 """
+[x1plusd-module]
+name=polar_cloud
+class_name=PolarPrintService
+requires_router=false
+settings_key=polar_cloud
+start_func=begin
+default_state=false
+[end]
+
 Module to allow printing using Polar Cloud service.
 """
 

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
@@ -1,3 +1,12 @@
+"""
+[x1plusd-module]
+name=sensors
+class_name=SensorsService
+requires_router=true
+settings_key=x1plusd.modules.sensors
+default_state=true
+[end]
+"""
 import logging
 import asyncio
 import time
@@ -35,6 +44,7 @@ class SensorsService(X1PlusDBusService):
 
         await self.emit_signal("SensorUpdate", { name: data })
         
-        # use the "synthesize_report" mechanism in mqtt_reroute.cpp to make
-        # device_gate publish both to the local mqtt broker and to the cloud
-        await self.daemon.mqtt.publish_request({ "x1plus": { "synthesize_report": { "x1plus": { "sensor": { name: data } } } } })
+        if hasattr(self.daemon, 'mqtt'):
+            # use the "synthesize_report" mechanism in mqtt_reroute.cpp to make
+            # device_gate publish both to the local mqtt broker and to the cloud
+            await self.daemon.mqtt.publish_request({ "x1plus": { "synthesize_report": { "x1plus": { "sensor": { name: data } } } } })

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sensors.py
@@ -1,12 +1,3 @@
-"""
-[x1plusd-module]
-name=sensors
-class_name=SensorsService
-requires_router=true
-settings_key=x1plusd.modules.sensors
-default_state=true
-[end]
-"""
 import logging
 import asyncio
 import time

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sshd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sshd.py
@@ -1,3 +1,13 @@
+"""
+[x1plusd-module]
+name=sshd
+class_name=SSHService
+requires_router=false
+settings_key=x1plusd.modules.sshd
+start_func=null
+default_state=true
+[end]
+"""
 import base64
 import os
 import subprocess

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sshd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sshd.py
@@ -1,13 +1,3 @@
-"""
-[x1plusd-module]
-name=sshd
-class_name=SSHService
-requires_router=false
-settings_key=x1plusd.modules.sshd
-start_func=null
-default_state=true
-[end]
-"""
 import base64
 import os
 import subprocess

--- a/images/cfw/opt/x1plus/lib/python/x1plus/utils.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/utils.py
@@ -1,7 +1,11 @@
 import subprocess
 from functools import lru_cache
 import os
+import re
+import importlib
+import logging, logging.handlers
 
+logger = logging.getLogger(__name__)
 
 @lru_cache(None)
 def is_emulating():
@@ -34,3 +38,41 @@ def get_IP() -> str:
     #     return "192.168.2.113"
     # hostname = subprocess.run(["hostname", "-I"], capture_output=True)
     # return hostname.stdout.decode().split(" ")[0]
+
+
+def module_loader(filepath, package_name):
+    """Return imported module from provided package and filepath, or None"""
+    module_name = os.path.splitext(os.path.basename(filepath))[0]
+    try:
+        module = importlib.import_module(f"{package_name}.{module_name}")
+    except Exception as e:
+        return None, None
+    return module, module_name
+
+def module_docstring_parser(filepath: str, loader_type: str) -> dict:
+        content = None
+        config = {}
+        try:
+            with open(filepath, 'r') as file:
+                content = file.read()
+        except Exception as e:
+            logger.warn(f"Could not load {filepath} in {loader_type} loader. {e.__class__.__name__}: {e}")
+            return config
+        
+        docstring_match = re.match(r"^([\"']{3})(.*?)\1", content, re.DOTALL)
+        if not docstring_match:
+            logger.debug(f"No docstring found for {filepath} for {loader_type} loader")
+            return config
+        
+        docstring = docstring_match.group(2).strip()
+        definition_block_match = re.search(rf"\[{re.escape(loader_type)}\](.*?)\[end\]", docstring, re.DOTALL)
+        if not definition_block_match:
+            logger.debug(f"Could not find module definition in docstring for {filepath} for {loader_type} loader")
+            return config
+
+        definition_block = definition_block_match.group(1).strip()
+        for line in definition_block.splitlines():
+            if "=" in line:
+                key, val = map(str.strip, line.split("=", 1))
+                config[key] = val
+        return config

--- a/images/cfw/opt/x1plus/lib/python/x1plus/utils.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/utils.py
@@ -50,29 +50,30 @@ def module_loader(filepath, package_name):
     return module, module_name
 
 def module_docstring_parser(filepath: str, loader_type: str) -> dict:
-        content = None
-        config = {}
-        try:
-            with open(filepath, 'r') as file:
-                content = file.read()
-        except Exception as e:
-            logger.warn(f"Could not load {filepath} in {loader_type} loader. {e.__class__.__name__}: {e}")
-            return config
-        
-        docstring_match = re.match(r"^([\"']{3})(.*?)\1", content, re.DOTALL)
-        if not docstring_match:
-            logger.debug(f"No docstring found for {filepath} for {loader_type} loader")
-            return config
-        
-        docstring = docstring_match.group(2).strip()
-        definition_block_match = re.search(rf"\[{re.escape(loader_type)}\](.*?)\[end\]", docstring, re.DOTALL)
-        if not definition_block_match:
-            logger.debug(f"Could not find module definition in docstring for {filepath} for {loader_type} loader")
-            return config
-
-        definition_block = definition_block_match.group(1).strip()
-        for line in definition_block.splitlines():
-            if "=" in line:
-                key, val = map(str.strip, line.split("=", 1))
-                config[key] = val
+    """Return dict for docstring values matching in a pre-defined block"""
+    content = None
+    config = {}
+    try:
+        with open(filepath, 'r') as file:
+            content = file.read()
+    except Exception as e:
+        logger.warn(f"Could not load {filepath} in {loader_type} loader. {e.__class__.__name__}: {e}")
         return config
+    
+    docstring_match = re.match(r"^([\"']{3})(.*?)\1", content, re.DOTALL)
+    if not docstring_match:
+        logger.debug(f"No docstring found for {filepath} for {loader_type} loader")
+        return config
+    
+    docstring = docstring_match.group(2).strip()
+    definition_block_match = re.search(rf"\[{re.escape(loader_type)}\](.*?)\[end\]", docstring, re.DOTALL)
+    if not definition_block_match:
+        logger.debug(f"Could not find module definition in docstring for {filepath} for {loader_type} loader")
+        return config
+
+    definition_block = definition_block_match.group(1).strip()
+    for line in definition_block.splitlines():
+        if "=" in line:
+            key, val = map(str.strip, line.split("=", 1))
+            config[key] = val
+    return config


### PR DESCRIPTION
Expanding on the WIP i2c loading, I started working on dynamic x1plusd driver loading.

- x1plusd will always require the settings module and dbus module, and are not dynamically loaded
- Module files will be either within `x1plusd` package or a single subpackage folder within the same directory.
- Each module file has a definition block in the docstring which provides the module name, class to import, if it requires the router, key in settings to enable/disable the module loading, default import state if no setting found, required module dependencies, and start function to run as an asyncio task.
- Modules are imported with their respective package name, so relative imports and logging paths still work as expected
- If a module fails to import, only it will fail. During a fail, it won't be added to the daemon attributes, so any modules that depend on it will also not load.
- On module failure, the settings key is still watched for changes.
- Any change to watched settings keys will trigger a full reload of x1plusd

Benefits are being able to choose which modules to load if some are not in use, and a consistent loading strategy that custom modules can match.

Additionally, I kept in the work for dynamically loading i2c drivers, but moved the validation also to a block in the docstring.

Module definition
```ini
[x1plusd-module]
name=name, required
class_name=ClassName, required. Class to load and import
requires_router=bool, default: false, does the class require the router to instantiate
settings_key=settings.path.for.bool, required, setting key to listen to for loading
start_func=function_name, default: task, set as 'null' if it does not have a start function. Runs as asyncio task
required_modules=module1,module2, default: none. Won't instantiate until all requirements are instanced
default_state=bool, default: false. Determines its default enabled state when not present in settings
[end]
```
i2c driver definition
```ini
[i2c-driver]
name=name, required, must match the driver name in i2c configs
class_name=ClassName, required. Class to load and import
[end]
```

Things to do:

- Looking for suggestions for better naming and format of docstring blocks and other vars/logging. Especially on the implementation of settings keys for enabling module loading since it's configurable.
- Custom module directory: Created `custom` folder/package in x1plusd. We could symlink this to a spot on the SD card (also need to create __init__.py?). Untested, but setup exists for it.
  -  Could be separate PR/issue
- Currently, I loop through the detected modules and adding ones with requirements satisfied until a max iteration count. Very basic but not ideal, could be improved with a proper ordered dependency list/map without a loop.
  - Could be separate PR/issue

~~Currently keeping this as draft as I test for about a week, and due to large changes to x1plusd, would be great to have a secondary test as well.~~

Have tested for a week while printing and toggling on/off various modules, while testing stuff such as both i2c and the andon module. Seems stable.

Closes #386
Closes #399