### PR TITLE
Send JobId with Status

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/polar_cloud.py
@@ -594,6 +594,7 @@ class PolarPrintService(X1PlusDBusService):
                 "startTime": self.start_time.isoformat(),
                 "estimatedTime": int(self.estimated_print_time) * 60,
                 "printSeconds": time_used.total_seconds(),
+                "jobId": self.job_id,
                 "progressDetail": (
                     f"Printing Job: {self.file_name} "
                     "Percent Complete: "


### PR DESCRIPTION
Sending Job Id back to Cloud to make sure printer is printing cloud job and user hasn't started a local print job instead. Doing so allows Polar Cloud to display correct information to user.