### PR TITLE
Port to 00.00.32.39 (01.08.02.00), and nop out TPU for AMS complaints

### DIFF
--- a/bbl_screen-patch/Makefile
+++ b/bbl_screen-patch/Makefile
@@ -1,13 +1,14 @@
 -include ../localconfig.mk
 
 FIRMWARE ?= $(shell jq -r .ap ../installer/base.json)
+FIRMWARE_DEF = -DFIRMWARE_$(shell jq -r .ap ../installer/base.json | sed -e 's/\./_/g')
 QT5_INCL_PATH ?= /usr/include/x86_64-linux-gnu/qt5/
 TOOLCHAIN ?= arm-linux-gnueabihf-
 TARGET_CC ?= $(TOOLCHAIN)gcc
 TARGET_CXX ?= $(TOOLCHAIN)g++
 LDFLAGS = -shared -ldl
-CXXFLAGS = -fPIC -std=c++11 -Ivendor -O3 -mcpu=cortex-a7 -Wno-psabi # yes, -O3 actually helps here with the VNC shenanigans
-CFLAGS = -fPIC -Ivendor -O3 -mcpu=cortex-a7 # yes, -O3 actually helps here with the VNC shenanigans
+CXXFLAGS = -fPIC -std=c++11 -Ivendor -O3 -mcpu=cortex-a7 -Wno-psabi $(FIRMWARE_DEF) # yes, -O3 actually helps here with the VNC shenanigans
+CFLAGS = -fPIC -Ivendor -O3 -mcpu=cortex-a7 $(FIRMWARE_DEF) # yes, -O3 actually helps here with the VNC shenanigans
 MODULES := kexec_ui.so printer_ui printer_ui.so printer_ui.so.xdelta uncurl.so evdev_fix.so base.ts workaround_ifaddrs.so device_gate_shim.so netService_shim.so forward_shim.so
 
 .DELETE_ON_ERROR:

--- a/bbl_screen-patch/interpose.cpp
+++ b/bbl_screen-patch/interpose.cpp
@@ -746,7 +746,7 @@ SWIZZLE(int, _Z17get_resource_path19bbl_resource_type_tRNSt7__cxx1112basic_strin
         try {
             json j = json::parse(settings);
             auto k = j.at("filament.filename").template get<std::string>();
-            printf("get_resource_path: read filement.filename setting from x1plusd of %s\n", k.c_str());
+            printf("get_resource_path: read filament.filename setting from x1plusd of %s\n", k.c_str());
             override = k;
         } catch(...) {
         };

--- a/bbl_screen-patch/netService_shim.cpp
+++ b/bbl_screen-patch/netService_shim.cpp
@@ -11,6 +11,44 @@
 #include <unistd.h>
 #include <syslog.h>
 
+#if defined(FIRMWARE_00_00_32_18)
+#  define OFS_ETH_VTABLE   0xA1FA8
+#  define OFS_ETH_VTABLE_0 0x56A4C
+#  define OFS_ETH_VTABLE_1 0x56A64
+#  define OFS_ETH_VTABLE_2 0x63434 /* not for us? */
+#  define OFS_ETH_VTABLE_3 0x56AD4
+#  define OFS_ETH_VTABLE_4 0x56AD8
+#  define OFS_CREATE_INTERFACES 0x49D3C
+#  define CREATE_INTERFACES_SIZE_1 0x380
+#  define OFS_CTOR_INTERFACE 0x6F988
+#  define OFS_SET_ADD_STRING_MAYBE 0x5A948
+#  define OFS_VTABLE_NETINTERFACECARD 0xA1FC4
+#  define OFS_CTOR_NETINTERFACECARD 0x28F94
+#  define OFS_SpCountedBase_M_RELEASE 0x3108c
+#  define OFS_NIC_init_dev 0x2E810
+#  define OFS_create_net_thread 0x287B0
+#  define OFS_ctor_size_218 0x5a948
+#elif defined(FIRMWARE_00_00_32_39)
+#  define OFS_ETH_VTABLE    0xA2734
+#  define OFS_ETH_VTABLE_0  0x56B5C
+#  define OFS_ETH_VTABLE_1  0x56B74
+#  define OFS_ETH_VTABLE_2  0x63608 /* not for us? */
+#  define OFS_ETH_VTABLE_3  0x56BE4
+#  define OFS_ETH_VTABLE_4  0x56BE8
+#  define OFS_CREATE_INTERFACES 0x49e4c
+#  define CREATE_INTERFACES_SIZE_1 0x380
+#  define OFS_CTOR_INTERFACE  0x6fb60
+#  define OFS_SET_ADD_STRING_MAYBE 0x5aa58
+#  define OFS_VTABLE_NETINTERFACECARD 0xA2750
+#  define OFS_CTOR_NETINTERFACECARD 0x28F94
+#  define OFS_SpCountedBase_M_RELEASE 0x31170
+#  define OFS_NIC_init_dev 0x2e8f4
+#  define OFS_create_net_thread 0x287b0
+#  define OFS_ctor_size_218 0x8779c
+#else
+#  error no offsets defined for this firmware?
+#endif
+
 #if 0
 extern "C" void syslog(int priority, const char *format, ...)
 {
@@ -31,11 +69,11 @@ void sub_57D50(unsigned int *a1)
 
 unsigned int eth_vtbl[] =
 {
-	0x00056A4C,
-	0x00056A64,
+	OFS_ETH_VTABLE_0,
+	OFS_ETH_VTABLE_1,
 	(unsigned int) sub_57D50,
-	0x00056AD4,
-	0x00056AD8
+	OFS_ETH_VTABLE_3,
+	OFS_ETH_VTABLE_4
 };
 
 static int create_interfaces(int thiz)
@@ -44,58 +82,58 @@ static int create_interfaces(int thiz)
 
 	syslog(6, "%s", "create_interfaces");
 
-	unsigned int *wlan_ptr = (unsigned int *)operator new(0x380);
-	wlan_ptr[0] = 0xA1FA8;
+	unsigned int *wlan_ptr = (unsigned int *)operator new(CREATE_INTERFACES_SIZE_1);
+	wlan_ptr[0] = OFS_ETH_VTABLE;
 	wlan_ptr[1] = 1;
 	wlan_ptr[2] = 1;
 	
 	{
 	std::string iface = "wlan0";
-	((void (*)(int, std::string &)) 0x6F988)((int)(wlan_ptr + 4), iface);
+	((void (*)(int, std::string &)) OFS_CTOR_INTERFACE)((int)(wlan_ptr + 4), iface);
 	}
 
 	{
 	std::string iface = "wlan0";
-	unsigned int *v4 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int *v4 = ((unsigned int *(*)(int, std::string &)) OFS_SET_ADD_STRING_MAYBE)(v3, iface);
 
 	unsigned int *v5 = (unsigned int *)operator new(0x130);
-	v5[0] = 0xA1FC4;
+	v5[0] = OFS_VTABLE_NETINTERFACECARD;
 	v5[1] = 1;
 	v5[2] = 1;
 
-	((void (*)(int)) 0x28F94)((int)(v5 + 4));
+	((void (*)(int)) OFS_CTOR_NETINTERFACECARD)((int)(v5 + 4));
 
 	unsigned int *v6 = (unsigned int *)v4[1];
 	v4[0] = (unsigned int) (v5 + 4);
 	v4[1] = (unsigned int) v5;
 
 	if (v6)
-		((void (*)(unsigned int *)) 0x3108C)(v6);
+		((void (*)(unsigned int *)) OFS_SpCountedBase_M_RELEASE)(v6);
 	}
 
 	{
 	std::string iface = "wlan0";
-	unsigned int v7 = *((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int v7 = *((unsigned int *(*)(int, std::string &)) OFS_SET_ADD_STRING_MAYBE)(v3, iface);
 	unsigned int *v12[2];
 	v12[0] = wlan_ptr + 4;
 	v12[1] = wlan_ptr;
 	
         __gnu_cxx::__exchange_and_add_dispatch((int *) &wlan_ptr[1], 1);
 
-        ((void (*)(unsigned int, unsigned int **)) 0x2E810)(v7, v12);
+        ((void (*)(unsigned int, unsigned int **)) OFS_NIC_init_dev)(v7, v12);
 	if (v12[1])
-		((void (*)(unsigned int *)) 0x3108C)(v12[1]);
+		((void (*)(unsigned int *)) OFS_SpCountedBase_M_RELEASE)(v12[1]);
 	}
 	
 	{
 	std::string iface = "wlan0";
-	unsigned int *v10 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int *v10 = ((unsigned int *(*)(int, std::string &)) OFS_SET_ADD_STRING_MAYBE)(v3, iface);
 
-	((void (*)(unsigned int)) 0x287B0)(*v10);
+	((void (*)(unsigned int)) OFS_create_net_thread)(*v10);
 	}
 
 	(*(void (**)(unsigned int *))(wlan_ptr[4] + 40))(wlan_ptr + 4);
-	((void (*)(unsigned int *)) 0x3108C)(wlan_ptr);
+	((void (*)(unsigned int *)) OFS_SpCountedBase_M_RELEASE)(wlan_ptr);
 	
 	syslog(6, "%s", "[NetService::create_interfaces] enable wired network");
 	
@@ -111,46 +149,46 @@ static int create_interfaces(int thiz)
 
 	{
 	std::string iface = "eth0";
-	unsigned int *v21 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int *v21 = ((unsigned int *(*)(int, std::string &)) OFS_ctor_size_218)(v3, iface);
 
 	unsigned int *v14 = (unsigned int *)operator new(0x130);
-	v14[0] = 0xA1FC4;
+	v14[0] = OFS_VTABLE_NETINTERFACECARD;
 	v14[1] = 1;
 	v14[2] = 1;
-	((void (*)(int)) 0x28F94)((int)(v14 + 4));
+	((void (*)(int)) OFS_CTOR_NETINTERFACECARD)((int)(v14 + 4));
 	
 	unsigned int *v15 = (unsigned int *)v21[1];
 	v21[0] = (unsigned int) (v14 + 4);
 	v21[1] = (unsigned int) v14;
 	
 	if (v15)
-		((void (*)(unsigned int *)) 0x3108C)(v15);
+		((void (*)(unsigned int *)) OFS_SpCountedBase_M_RELEASE)(v15);
 	}
 
 	{
 	std::string iface = "eth0";
-	unsigned int v16 = *((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int v16 = *((unsigned int *(*)(int, std::string &)) OFS_SET_ADD_STRING_MAYBE)(v3, iface);
 	unsigned int *v22[2];
 	v22[0] = eth_ptr + 4;
 	v22[1] = eth_ptr;
 	
         __gnu_cxx::__exchange_and_add_dispatch((int *) &eth_ptr[1], 1);
 
-        ((void (*)(unsigned int, unsigned int **)) 0x2E810)(v16, v22);
+        ((void (*)(unsigned int, unsigned int **)) OFS_NIC_init_dev)(v16, v22);
 	if (v22[1])
-		((void (*)(unsigned int *)) 0x3108C)(v22[1]);
+		((void (*)(unsigned int *)) OFS_SpCountedBase_M_RELEASE)(v22[1]);
 	}
 	
 	{
 	std::string iface = "eth0";
-	unsigned int *v19 = ((unsigned int *(*)(int, std::string &)) 0x5A948)(v3, iface);
+	unsigned int *v19 = ((unsigned int *(*)(int, std::string &)) OFS_ctor_size_218)(v3, iface);
 
-	((void (*)(unsigned int)) 0x287B0)(*v19);
+	((void (*)(unsigned int)) OFS_create_net_thread)(*v19);
 	}
 
 	(*(void (**)(unsigned int *))(eth_ptr[4] + 40))(eth_ptr + 4);
 
-	((void (*)(unsigned int *)) 0x3108C)(eth_ptr);	
+	((void (*)(unsigned int *)) OFS_SpCountedBase_M_RELEASE)(eth_ptr);	
 	
 	return 0;
 }
@@ -164,14 +202,14 @@ extern "C" void __attribute__ ((constructor)) init() {
 		0xe3019ce8,
 		0xe340900c
 	};
-	if (memcmp((void *)0x49d3c, expect_insns, 12)) {
+	if (memcmp((void *)OFS_CREATE_INTERFACES, expect_insns, 12)) {
 		fprintf(stderr, "*** NETSERVICE DOES NOT HAVE EXPECTED BYTE SEQUENCE.  FIRMWARE HAS CHANGED; YOU MUST UPDATE netService_shim.cpp.\n");
 		abort();
 	}
 
-	mprotect((void *)((long)0x00049D3C & ~(sysconf(_SC_PAGESIZE) - 1)), sysconf(_SC_PAGESIZE), PROT_READ | PROT_WRITE | PROT_EXEC);
+	mprotect((void *)((long)OFS_CREATE_INTERFACES & ~(sysconf(_SC_PAGESIZE) - 1)), sysconf(_SC_PAGESIZE), PROT_READ | PROT_WRITE | PROT_EXEC);
 	
-	*(uint32_t *) 0x00049D3C = 0xE59F1000;
-	*(uint32_t *) 0x00049D40 = 0xE12FFF11;
-	*(uint32_t *) 0x00049D44 = (uint32_t)create_interfaces;
+	((uint32_t *)OFS_CREATE_INTERFACES)[0] = 0xE59F1000;
+	((uint32_t *)OFS_CREATE_INTERFACES)[1] = 0xE12FFF11;
+	((uint32_t *)OFS_CREATE_INTERFACES)[2] = (uint32_t)create_interfaces;
 }

--- a/bbl_screen-patch/netService_shim.cpp
+++ b/bbl_screen-patch/netService_shim.cpp
@@ -27,7 +27,7 @@
 #  define OFS_SpCountedBase_M_RELEASE 0x3108c
 #  define OFS_NIC_init_dev 0x2E810
 #  define OFS_create_net_thread 0x287B0
-#  define OFS_ctor_size_218 0x5a948
+#  define OFS_ctor_size_218 0x875c4
 #elif defined(FIRMWARE_00_00_32_39)
 #  define OFS_ETH_VTABLE    0xA2734
 #  define OFS_ETH_VTABLE_0  0x56B5C
@@ -144,12 +144,12 @@ static int create_interfaces(int thiz)
 	
 	{
 	std::string iface = "eth0";
-	((void (*)(int, std::string &)) 0x875C4)((int)(eth_ptr + 4), iface);
+	((void (*)(int, std::string &)) OFS_ctor_size_218)((int)(eth_ptr + 4), iface);
 	}
 
 	{
 	std::string iface = "eth0";
-	unsigned int *v21 = ((unsigned int *(*)(int, std::string &)) OFS_ctor_size_218)(v3, iface);
+	unsigned int *v21 = ((unsigned int *(*)(int, std::string &)) OFS_SET_ADD_STRING_MAYBE)(v3, iface);
 
 	unsigned int *v14 = (unsigned int *)operator new(0x130);
 	v14[0] = OFS_VTABLE_NETINTERFACECARD;
@@ -181,7 +181,7 @@ static int create_interfaces(int thiz)
 	
 	{
 	std::string iface = "eth0";
-	unsigned int *v19 = ((unsigned int *(*)(int, std::string &)) OFS_ctor_size_218)(v3, iface);
+	unsigned int *v19 = ((unsigned int *(*)(int, std::string &)) OFS_SET_ADD_STRING_MAYBE)(v3, iface);
 
 	((void (*)(unsigned int)) OFS_create_net_thread)(*v19);
 	}

--- a/bbl_screen-patch/patches/printerui/app_cn.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_cn.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_cn.ts
 +++ printer_ui/printerui/app_cn.ts
-@@ -3431,4 +3431,316 @@
+@@ -3492,4 +3492,316 @@
          <translation>请确认是否取消本次打印？</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/app_de.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_de.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_de.ts
 +++ printer_ui/printerui/app_de.ts
-@@ -3435,4 +3435,410 @@
+@@ -3496,4 +3496,410 @@
          <translation>Sind Sie sich sicher, dass sie diesen Druck abbrechen wollen?</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/app_es.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_es.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_es.ts
 +++ printer_ui/printerui/app_es.ts
-@@ -3437,4 +3437,1170 @@
+@@ -3498,4 +3498,1170 @@
          <translation>¿Estás seguro de que quieres cancelar este trabajo?</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/app_fr.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_fr.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_fr.ts
 +++ printer_ui/printerui/app_fr.ts
-@@ -3432,4 +3432,262 @@
+@@ -3493,4 +3493,262 @@
          <translation>Voulez-vous vraiment annuler cette tâche ?</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/app_ja.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_ja.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_ja.ts
 +++ printer_ui/printerui/app_ja.ts
-@@ -3433,4 +3433,976 @@
+@@ -3494,4 +3494,976 @@
          <translation>今の造形を取り消しますか？</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/app_nl.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_nl.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_nl.ts
 +++ printer_ui/printerui/app_nl.ts
-@@ -3437,4 +3437,132 @@
+@@ -3498,4 +3498,132 @@
          <translation>Weet u zeker dat u deze opdracht wilt annuleren?</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/app_sv.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_sv.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_sv.ts
 +++ printer_ui/printerui/app_sv.ts
-@@ -3436,4 +3436,635 @@
+@@ -3497,4 +3497,635 @@
          <translation>Är du säker att du vill avbryta utskriften?</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/app_tw.ts.patch
+++ b/bbl_screen-patch/patches/printerui/app_tw.ts.patch
@@ -1,6 +1,6 @@
 --- printer_ui-orig/printerui/app_tw.ts
 +++ printer_ui/printerui/app_tw.ts
-@@ -3429,4 +3429,136 @@
+@@ -3490,4 +3490,136 @@
          <translation>请確認是否取消本次列印？</translation>
      </message>
  </context>

--- a/bbl_screen-patch/patches/printerui/qml/printer/FilamentPad.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/printer/FilamentPad.qml.patch
@@ -1,0 +1,25 @@
+--- printer_ui-orig/printerui/qml/printer/FilamentPad.qml
++++ printer_ui/printerui/qml/printer/FilamentPad.qml
+@@ -464,13 +464,15 @@
+ 
+                 if (filament.index !== 254) {
+                     if (nameCombo.currentText.indexOf("TPU") != -1 || (((vendorCombo.currentText == "Bambu Lab") || (vendorCombo.currentText == "Bambu")) && (nameCombo.currentText.indexOf("PET-CF") != -1 || nameCombo.currentText.indexOf("PA6-CF") != -1))) {
+-                        dialogStack.popupDialog(
+-                                    "TextConfirm", {
+-                                        name: "select filament info not supported",
+-                                        type: TextConfirm.CONFIRM_ONLY,
+-                                        text: qsTr("\"%1\" is not supported by AMS.").arg(editing.name)
+-                                    })
+-                        return
++                        if (nameCombo.currentText.indexOf("TPU for AMS") != -1) { /* I guess that's ok. */
++                            dialogStack.popupDialog(
++                                        "TextConfirm", {
++                                            name: "select filament info not supported",
++                                            type: TextConfirm.CONFIRM_ONLY,
++                                            text: qsTr("\"%1\" is not supported by AMS.").arg(editing.name)
++                                        })
++                            return
++                        }
+                     } else if(((vendorCombo.currentText == "Bambu Lab") || (vendorCombo.currentText == "Bambu")) && (nameCombo.currentText.indexOf("-CF") != -1 || nameCombo.currentText.indexOf("PVA") != -1)) {
+                         dialogStack.popupDialog(
+                                     "TextConfirm", {

--- a/bbl_screen-patch/patches/root.qrc.patch
+++ b/bbl_screen-patch/patches/root.qrc.patch
@@ -123,13 +123,14 @@
  <file>printerui/qml/settings/MaintenancePage.qml</file>
  <file>printerui/qml/settings/NetParaSetPage.qml</file>
  <file>printerui/qml/settings/NetworkPage.qml</file>
-@@ -217,11 +272,16 @@
+@@ -217,12 +272,16 @@
  <file>printerui/qml/settings/RegionItem.qml</file>
  <file>printerui/qml/settings/ReleaseNotePage.qml</file>
  <file>printerui/qml/settings/SensorPage.qml</file>
 +<file>printerui/qml/settings/ScreenLock.qml</file>
 +<file>printerui/qml/settings/ScreenLockPage.qml</file>
  <file>printerui/qml/settings/SettingListener.qml</file>
+-<file>printerui/qml/settings/UpdateWithPackagePage.qml</file>
  <file>printerui/qml/settings/UpdatingPage.qml</file>
 -<file>printerui/qml/settings/VersionPage.qml</file>
 +<file>printerui/qml/settings/UpgradeDialog.qml</file>
@@ -141,7 +142,7 @@
  <file>printerui/qml/wizard/Calibrate1Page.qml</file>
  <file>printerui/qml/wizard/CalibratePage.qml</file>
  <file>printerui/qml/wizard/CalibratingPage.qml</file>
-@@ -235,12 +295,34 @@
+@@ -236,12 +295,34 @@
  <file>printerui/qml/wizard/TermsPage.qml</file>
  <file>printerui/qml/wizard/WelcomePage.qml</file>
  <file>printerui/qml/wizard/WizardPage.qml</file>
@@ -176,7 +177,7 @@
  <file>printerui/text/error_texts.sv.json</file>
  <file>printerui/text/error_texts.zh-cn.json</file>
  <file>printerui/text/error_texts.zh-tw.json</file>
-@@ -259,6 +341,9 @@
+@@ -260,6 +341,9 @@
  <file>printerui/text/hms_texts.fr.json</file>
  <file>printerui/text/hms_texts.ja.json</file>
  <file>printerui/text/hms_texts.nl.json</file>
@@ -186,7 +187,7 @@
  <file>printerui/text/hms_texts.sv.json</file>
  <file>printerui/text/hms_texts.zh-cn.json</file>
  <file>printerui/text/hms_texts.zh-tw.json</file>
-@@ -295,3 +380,4 @@
+@@ -296,3 +380,4 @@
  <file>printerui/text/terms.zh-cn.txt</file>
  <file>qt-project.org/imports/QtQuick/VirtualKeyboard/Styles/bbl/style.qml</file>
  </qresource></RCC>

--- a/firmwares/Makefile
+++ b/firmwares/Makefile
@@ -57,3 +57,6 @@ endef
 
 00.00.32.18.squashfs:
 	$(call fetchimage_fullurl,https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25,update-v00.00.32.18-20240422102213_product.img.zip.sig,$@)
+
+00.00.32.39.squashfs:
+	$(call fetchimage_fullurl,https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.02.00/product/e750866b34,update-v00.00.32.39-20240805174856_product.img.zip.sig,$@)

--- a/installer/base.json
+++ b/installer/base.json
@@ -5,7 +5,7 @@
     "updateName": "update-v00.00.32.39-20240805174856_product.img.zip.sig",
     "updateMd5": "1e1003789a9ea7326c206aa99c174632",
     "squashfsName": "00.00.32.39.squashfs",
-    "squashfsMd5": "11153f2d890fc774687c960c96b1fa77",
+    "squashfsMd5": "6c2a1c7a06334de22c06499272325bc3",
     "mtime": 1737610560,
     "modules": {
         "cfw": { "dialogName": "X1Plus firmware", "version": "[version]", "alwaysNoUpgrade": true, "noUpgrade": "COPY_NEW_X1P" },

--- a/installer/base.json
+++ b/installer/base.json
@@ -1,6 +1,6 @@
 {
     "version": "01.08.00.00",
-    "ap": "00.00.32.18",
+    "ap": "00.00.32.39",
     "updateUrl": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25/update-v00.00.32.18-20240422102213_product.img.zip.sig",
     "updateName": "update-v00.00.32.18-20240422102213_product.img.zip.sig",
     "updateMd5": "af197ded334dea01e5ce95ee56155e0a",

--- a/installer/base.json
+++ b/installer/base.json
@@ -1,12 +1,12 @@
 {
-    "version": "01.08.00.00",
+    "version": "01.08.02.00",
     "ap": "00.00.32.39",
-    "updateUrl": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.00.00/product/45ea644d25/update-v00.00.32.18-20240422102213_product.img.zip.sig",
-    "updateName": "update-v00.00.32.18-20240422102213_product.img.zip.sig",
-    "updateMd5": "af197ded334dea01e5ce95ee56155e0a",
-    "squashfsName": "00.00.32.18.squashfs",
+    "updateUrl": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/01.08.02.00/product/e750866b34/update-v00.00.32.39-20240805174856_product.img.zip.sig",
+    "updateName": "update-v00.00.32.39-20240805174856_product.img.zip.sig",
+    "updateMd5": "1e1003789a9ea7326c206aa99c174632",
+    "squashfsName": "00.00.32.39.squashfs",
     "squashfsMd5": "11153f2d890fc774687c960c96b1fa77",
-    "mtime": 1715067071,
+    "mtime": 1737610560,
     "modules": {
         "cfw": { "dialogName": "X1Plus firmware", "version": "[version]", "alwaysNoUpgrade": true, "noUpgrade": "COPY_NEW_X1P" },
         "ota": { "dialogName": "Bambu Lab base firmware", "version": "[version]", "alwaysNoUpgrade": true, "noUpgrade": "COPY_NEW_X1P" },


### PR DESCRIPTION
Changes in 00.00.32.39 are relatively minimal; kick everything forward (and make the netservice shim symbolized to be able to port it to other firmware versions in the future).  While we're in there, nop out the complaints about TPU from bbl_screen, when it's TPU for AMS.