### PR TITLE
Add Option to toggle light with hardware buttons

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/x1plus/GpioKeys.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/GpioKeys.js
@@ -12,6 +12,7 @@ const ACTION_REBOOT = "ACTION_REBOOT";
 const ACTION_PAUSE_PRINT = "ACTION_PAUSE";
 const ACTION_ABORT_PRINT = "ACTION_ABORT";
 const ACTION_RUN_MACRO = "ACTION_MACRO";
+const ACTION_TOGGLE_LIGHT = "ACTION_TOGGLE_LIGHT";
 const ACTION_NONE = "ACTION_NONE";
 
 const DEFAULTS = {
@@ -24,6 +25,7 @@ const BUTTON_ACTIONS = [
     { name: QT_TR_NOOP("Reboot"), val: ACTION_REBOOT },
     { name: QT_TR_NOOP("Pause print"), val: ACTION_PAUSE_PRINT},
     { name: QT_TR_NOOP("Abort print"), val: ACTION_ABORT_PRINT },
+    { name: QT_TR_NOOP("Toggle Light"), val: ACTION_TOGGLE_LIGHT },
     { name: QT_TR_NOOP("Ignore"), val: ACTION_NONE },
     /* { name: QT_TR_NOOP("Run macro"), val: ACTION_RUN_MACRO }, */
 ];
@@ -142,6 +144,9 @@ function _handleButton(button, event) {
             } else {
                 X1Plus.DeviceManager.power.externalWakeup();
             }
+            break;
+        case ACTION_TOGGLE_LIGHT:
+            X1Plus.DeviceManager.isLightOn = !X1Plus.DeviceManager.isLightOn;
             break;
         case ACTION_NONE:
             break;


### PR DESCRIPTION
This is my first PR here, so I hope I modified things correctly.

This is a small change to add an option for "Toggle Light" to the Hardware Settings Page for the physical buttons. This toggles the main/chamber light, the same way the lightbulb button in the touchscreen UI does.

Right now if the touchscreen is active and on the main screen, when the hardware button is used to toggle the light the lightbulb icon on the screen switches between on and of two times until it settles on the correct new state. I'm not sure if this can be fixed/improved, since I haven't worked with qml before. I can however look into it further.