### PR TITLE
bbl_screen: add support to update filament database from Bambu Lab

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/UpgradeDialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/UpgradeDialog.qml
@@ -148,6 +148,21 @@ Item {
                 "command": "consistency_confirm",
                 "sequence_id": "0"
             });
+        } else if (module == "filament") {
+            // This one is easy -- we just copy it into the right place,
+            // update the X1Plus Setting, then say we're good.
+            X1PlusNative.system(`mkdir /userdata/firmware/filament`);
+            X1PlusNative.system(`cp /sdcard/x1plus/firmware/${fileName} /userdata/firmware/filament/${fileName}`);
+            X1Plus.Settings.put("filament.ota_version", fileName);
+            
+            // retrigger filament database reload: set this to something
+            // else, then set it back
+            var old_diameter = DeviceManager.maintain.nozzleDiameter;
+            DeviceManager.maintain.nozzleDiameter = "";
+            DeviceManager.maintain.nozzleDiameter = DeviceManager.maintain.nozzleDiameter;
+            
+            isInstalling = false;
+            didInstall = true;
         } else {
             // thttpd looks in /tmp/firmware, not /sdcard/x1plus/firmware,
             // because sdcard file modes have +x, and thttpd will die from
@@ -315,7 +330,7 @@ Item {
                 font: Fonts.body_26
                 color: Colors.gray_200
                 wrapMode: Text.Wrap
-                visible: didInstall && updater.status != Updater.UPGRADE_FAIL
+                visible: didInstall && (module == "filament" || updater.status != Updater.UPGRADE_FAIL)
                 text: qsTr("Successfully installed version %1.").arg(version)
             }
 
@@ -325,7 +340,7 @@ Item {
                 font: Fonts.body_26
                 color: Colors.gray_200
                 wrapMode: Text.Wrap
-                visible: didInstall && updater.status == Updater.UPGRADE_FAIL
+                visible: didInstall && (module != "filament" && updater.status == Updater.UPGRADE_FAIL)
                 text: qsTr("Version %1 failed to install. Consider trying again, or power cycling your printer.").arg(version) +
                     (updater.message != '' ? qsTr(" (Updater message \"%1\".)").arg(updater.message) : '')
             }

--- a/bbl_screen-patch/patches/printerui/qml/settings/VersionDialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/VersionDialog.qml
@@ -11,7 +11,11 @@ Item {
     property var cfwVersion: ({}) /* from cfwversions.json: version, ... */
     property var mappedData: ({}) /* hw_ver, sn, sw_ver */
     property var isHw: (mappedData.sn && mappedData.sn != "" && mappedData.hw_ver && mappedData.hw_ver != "")
-    property var needsUpdate: (!cfwVersion.invalid && mappedData.sn != "N/A" && mappedData.sw_ver.split("/")[0] != cfwVersion.version)
+    property var needsUpdate: modelData.bambu == "filament" ? mappedData.sw_ver != "Custom" && mappedData.sw_ver < cfwVersion.version :
+                              (!cfwVersion.invalid && mappedData.sn != "N/A" && mappedData.sw_ver.split("/")[0] != cfwVersion.version)
+    property var sw_ver_text: modelData.bambu == "filament" && mappedData.sw_ver == "Custom" ? qsTr("Custom") :
+                              modelData.bambu == "filament" && mappedData.sw_ver == "" ? qsTr("Not installed") :
+                              mappedData.sw_ver.split("/")[0]
     
     property var noUpgrade_messages: ({
         "COPY_NEW_X1P": QT_TR_NOOP("To install a new version of the custom firmware, copy the new x1p file to the root of the SD card, power cycle the printer, and select the installer at startup time."),
@@ -110,7 +114,7 @@ Item {
                 color: Colors.gray_200
                 wrapMode: Text.Wrap
                 Layout.columnSpan: 2
-                text: qsTr("<b>Firmware version</b>: %1").arg(mappedData.sw_ver.split("/")[0]) +
+                text: qsTr("<b>Firmware version</b>: %1").arg(sw_ver_text) +
                     (needsUpdate ? qsTr(" (<font color='#ff6f00'><i>recommended: %1</i></font>)").arg(cfwVersion.version.split("/")[0]) : "")
             }
             

--- a/bbl_screen-patch/patches/printerui/qml/settings/VersionPage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/VersionPage.qml
@@ -15,6 +15,7 @@ Item {
         { "friendly": QT_TR_NOOP("AP board"), "bambu": "ap", "cfw": "rv1126", "icon": "../../icon/components/ap-board.svg" },
         { "friendly": QT_TR_NOOP("MC board"), "bambu": "mc", "cfw": "mc", "icon": "../../icon/components/mc-board.svg" },
         { "friendly": QT_TR_NOOP("Toolhead"), "bambu": "th", "cfw": "th", "icon": "../../icon/components/th.svg" },
+        { "friendly": QT_TR_NOOP("Filament database"), "bambu": "filament", "cfw": "filament", "icon": "../../icon/components/ams.svg" }, // XXX: do icon
         { "friendly": QT_TR_NOOP("AMS hub"), "bambu": "ahb", "cfw": "ahb", "icon": "../../icon/components/ahb.svg" },
         { "friendly": QT_TR_NOOP("AMS #1"), "bambu": "ams/0", "cfw": "ams", "icon": "../../icon/components/ams.svg" },
         { "friendly": QT_TR_NOOP("AMS #2"), "bambu": "ams/1", "cfw": "ams", "icon": "../../icon/components/ams.svg" },

--- a/bbl_screen-patch/patches/printerui/qml/settings/VersionPage.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/VersionPage.qml
@@ -115,8 +115,16 @@ Item {
             property var mappedData: (modelData.bambu === undefined ?
                                         {"sw_ver": cfwVersion.version, "sn": "", "hw_ver": "" } :
                                         modules.find(el => modelData.bambu == el.name))
-            property var needsUpdate: (!cfwVersion.invalid && mappedData.sn != "N/A" && mappedData.sw_ver.split("/")[0] != cfwVersion.version) ||
-                                      (modelData.cfw == 'cfw' && X1Plus.OTA.status()['ota_available'])
+            property var needsUpdate: modelData.bambu == "filament" ? mappedData.sw_ver != "Custom" && mappedData.sw_ver < cfwVersion.version :
+                                      modelData.cfw == 'cfw' ? X1Plus.OTA.status()['ota_available'] : 
+                                      (!cfwVersion.invalid && mappedData.sn != "N/A" && mappedData.sw_ver.split("/")[0] != cfwVersion.version)
+            
+            // a few translatable overrides go here...  annoyingly, this
+            // gets replicated in VersionDialog, but is there a better way
+            // given what we already have at this point?
+            property var sw_ver_text: modelData.bambu == "filament" && mappedData.sw_ver == "Custom" ? qsTr("Custom") :
+                                      modelData.bambu == "filament" && mappedData.sw_ver == "" ? qsTr("Not installed") :
+                                      mappedData.sw_ver.split("/")[0]
             width: ListView.view.width
             height: 81
             color: modelData.onClicked === undefined ? "transparent" : backColor.color
@@ -183,7 +191,7 @@ Item {
                     elide: Text.ElideRight
                     color: needsUpdate ? Colors.warning : Colors.gray_400
                     font: Fonts.body_26
-                    text: mappedData.sw_ver.split("/")[0]
+                    text: sw_ver_text
                 }
 
                 Image {

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/DDS.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/DDS.js
@@ -44,13 +44,20 @@ function requestVersions() {
             {"hw_ver":"","name":"xm","sn":"","sw_ver":"00.01.02.00"},
             {"hw_ver":"AHB00","name":"ahb","sn":"00K00A999999999","sw_ver":"00.00.00.42"},
             {"hw_ver":"AMS08","name":"ams/0","sn":"00600A999999998","sw_ver":"00.00.06.15"},
-            {"hw_ver":"AMS08","name":"ams/1","sn":"00600A999999999","sw_ver":"00.00.06.15"}
+            {"hw_ver":"AMS08","name":"ams/1","sn":"00600A999999999","sw_ver":"00.00.06.15"},
+            {"hw_ver":"","name":"filament","sn":"","sw_ver":"00.01.02.03"},
         ]);
     }
 }
 
 registerHandler("device/report/info", function(datum) {
     if (datum.command == "get_version") {
+        // Try to find a filament version.  Sort of a dirty hack, but oh
+        // well.
+        var filamentPath = _X1PlusNative.getFilamentPath();
+        var filamentVers = filamentPath.match(/v(\d\d\.\d\d\.\d\d\.\d\d)-\d+\.zip\.sig$/);
+        datum.module.push({ "hw_ver": "", "name": "filament", "sn": "", "sw_ver": filamentVers ? filamentVers[1] : !filamentPath ? "" : "Custom", "path": filamentPath });
+        
         _setVersions(datum.module);
     }
 });

--- a/installer/base.json
+++ b/installer/base.json
@@ -24,6 +24,9 @@
         "ams": { "version": "00.00.06.44", "paths": {
             "ams07": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-A001/00.00.06.44/product/8a38ace450/ams_rev7-firmware-v00.00.06.44-20240703093253_product.bin.sig", "md5": "9f52c896f0a349fc054290315db63e20" },
             "ams08": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-A001/00.00.06.44/product/8a38ace450/ams_rev8-firmware-v00.00.06.44-20240703093110_product.bin.sig", "md5": "9be1ccccd3ee5e0e63ef9214b322ad5e" }
+        } }, 
+        "filament": { "version": "01.10.00.37", "paths": {
+            "": {"url": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/filament/product/ota-filament-v01.10.00.37-20250310175234.zip.sig", "md5": "830234e972de9fe2072ba91929ec6270" }
         } }
     }
 }


### PR DESCRIPTION
In addition to being able to manually override the filament database (for those who might be hacking on the AMS), we add UI to download a recommended version of the firmware database, with some modern Bambu filaments in it.

Fixes #401.

![image](https://github.com/user-attachments/assets/6f0523b1-af83-43d3-90a5-ac0e8d838088)
