### PR TITLE
x1plusd: avoid exposing unauthenticated services

### DIFF
--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sshd.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/sshd.py
@@ -17,6 +17,8 @@ class SSHService():
         self.daemon.settings.on("ssh.enabled", lambda: self.sync_startstop())
         self.daemon.settings.on("ssh.root_password", lambda: self.set_password())
         
+        self.set_password()
+        
         self.sync_startstop()
     
     def sshd_is_running(self):


### PR DESCRIPTION
By default, the root password was `root` (#387), which meant that even if the sshd wasn't on, the ftpd would allow root access.  And by default, there was an adbd running on port 5555, which was also bad (#389).  x1plusd controls for both of these now on the way up.