### PR TITLE
add support for upgrading a secondary AMS

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/settings/UpgradeDialog.qml
+++ b/bbl_screen-patch/patches/printerui/qml/settings/UpgradeDialog.qml
@@ -182,14 +182,20 @@ Item {
             // running!  So we do that.
             X1PlusNative.system(`cp /sdcard/x1plus/firmware/${fileName} /userdata/firmware/${fileName}`);
             X1PlusNative.system(`chmod -x /userdata/firmware/${fileName}`);
-
-            X1Plus.DDS.publish("device/request/upgrade", {
+            
+            var upgrade_pkt = {
                 "command": "start",
                 "sequence_id": "0",
                 "module": module.split("/")[0], /* ams/0 -> ams */
                 "version": version,
                 "url": `http://127.0.0.1:8888/${fileName}`
-            });
+            };
+            
+            if (upgrade_pkt.module == 'ams') {
+                upgrade_pkt.submodule = parseInt(module.split("/")[1]);
+            }
+
+            X1Plus.DDS.publish("device/request/upgrade", upgrade_pkt);
         }
     }
 

--- a/installer/base.json
+++ b/installer/base.json
@@ -21,7 +21,7 @@
         "xm": { "version": "00.01.02.02", "paths": {
             "": { "url": "https://public-cdn.bambulab.com/upgrade/device/BL-P001/xm/00.01.02.02/product/xm_v00.01.02.02-20230328103404_product.rknn.sig", "md5": "50c4487de44fec31d63dd8f8c3464446" }
         } },
-        "ams": { "version": "00.01.06.42", "paths": {
+        "ams": { "version": "00.01.06.62", "paths": {
             "ams08": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-A001/00.01.06.62/product/3f9bc0542b/ams_rev8-firmware-v00.01.06.62-20250331204240_product.bin.sig", "md5": "61d0b28d20f1de27d341323116210f1f" }
         } }, 
         "filament": { "version": "02.00.00.89", "paths": {

--- a/installer/base.json
+++ b/installer/base.json
@@ -21,9 +21,8 @@
         "xm": { "version": "00.01.02.02", "paths": {
             "": { "url": "https://public-cdn.bambulab.com/upgrade/device/BL-P001/xm/00.01.02.02/product/xm_v00.01.02.02-20230328103404_product.rknn.sig", "md5": "50c4487de44fec31d63dd8f8c3464446" }
         } },
-        "ams": { "version": "00.00.06.44", "paths": {
-            "ams07": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-A001/00.00.06.44/product/8a38ace450/ams_rev7-firmware-v00.00.06.44-20240703093253_product.bin.sig", "md5": "9f52c896f0a349fc054290315db63e20" },
-            "ams08": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-A001/00.00.06.44/product/8a38ace450/ams_rev8-firmware-v00.00.06.44-20240703093110_product.bin.sig", "md5": "9be1ccccd3ee5e0e63ef9214b322ad5e" }
+        "ams": { "version": "00.01.06.42", "paths": {
+            "ams08": { "url": "https://public-cdn.bblmw.com/upgrade/device/BL-A001/00.01.06.62/product/3f9bc0542b/ams_rev8-firmware-v00.01.06.62-20250331204240_product.bin.sig", "md5": "61d0b28d20f1de27d341323116210f1f" }
         } }, 
         "filament": { "version": "02.00.00.89", "paths": {
             "": {"url": "https://public-cdn.bblmw.com/upgrade/device/BL-P001/filament/product/ota-filament-v02.00.00.89-20250506161431.zip.sig", "md5": "d04c4d74f71a77b4d383d1abb085f299" }


### PR DESCRIPTION
Also, use new AMS FW.

Fixes #496.