### PR TITLE
camera_watchdog: ipcam watchdog implementation

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/Screen.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/Screen.qml.patch
@@ -52,7 +52,7 @@
  
      Component.onCompleted: {
          Printer.jumpTo.connect(jumpTo)
-+        X1Plus.awaken(DeviceManager, PrintManager, NetworkManager, PrintTask, Network)
++        X1Plus.awaken(DeviceManager, PrintManager, NetworkManager, PrintTask, Network, RecordManager)
      }
  
      Loader {

--- a/bbl_screen-patch/patches/printerui/qml/X1Plus.js
+++ b/bbl_screen-patch/patches/printerui/qml/X1Plus.js
@@ -170,13 +170,14 @@ X1Plus.fileExists = fileExists;
  * they are loaded, and they might need to do work touching other modules. 
  * These things happen from 'awaken'.
  */
-function awaken(_DeviceManager, _PrintManager, _NetworkManager, _PrintTask, _Network) {
+function awaken(_DeviceManager, _PrintManager, _NetworkManager, _PrintTask, _Network, _RecordManager) {
 	console.log("X1Plus.js awakening");
 	X1Plus.DeviceManager = DeviceManager = _DeviceManager;
 	X1Plus.PrintManager = PrintManager = _PrintManager;
 	X1Plus.NetworkManager = NetworkManager = _NetworkManager;
 	X1Plus.PrintTask = PrintTask = _PrintTask;
 	X1Plus.NetworkEnum = NetworkEnum = _Network;
+	X1Plus.RecordManager = _RecordManager;
 	X1Plus.printerConfigDir = printerConfigDir = `/mnt/sdcard/x1plus/printers/${X1Plus.DeviceManager.build.seriaNO}`;
 	_X1PlusNative.system("mkdir -p " + _X1PlusNative.getenv("EMULATION_WORKAROUNDS") + printerConfigDir);
 	Settings.awaken();

--- a/bbl_screen-patch/patches/printerui/qml/x1plus/GpioKeys.js
+++ b/bbl_screen-patch/patches/printerui/qml/x1plus/GpioKeys.js
@@ -164,5 +164,14 @@ function awaken(){
             if (datum.gpio) {
                 _handleButton(datum.gpio.button, datum.gpio.event);
             }
+            
+            // this isn't technically gpiokeys, but it's convenient enough,
+            // since this is how x1plusd gets in touch with us.  only
+            // bbl_screen knows the key to restart the rtsp server, so we
+            // just let it do the job if x1plusd has to kick ipcam.
+            if (datum.restore_camera_rtsp !== undefined && X1Plus.RecordManager) {
+                console.log("[x1p] camera_watchdog: restoring RTSP server to", datum.restore_camera_rtsp);
+                X1Plus.RecordManager.rtspServerOn = datum.restore_camera_rtsp;
+            }
     });
 }

--- a/images/cfw/opt/x1plus/lib/python/x1plus/aiocamera.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/aiocamera.py
@@ -72,6 +72,7 @@ class AioRtspReceiver:
         self.got_seqparam = False
         self.got_picparam = False
         self.got_idr = False
+        result = None
 
         async with self.local_rtspreader() as reader:
             async for pkt in reader.iter_packets():
@@ -79,10 +80,15 @@ class AioRtspReceiver:
                 
                 if self.got_seqparam and self.got_picparam and self.got_idr:
                     logger.debug(f"received {len(self.received_nals)} bytes of h264")
-                    return self.received_nals
+                    result = self.received_nals
+                    break  # exit loop cleanly so context manager can send RTSP TEARDOWN
+
+        return result
     
     async def receive_jpeg(self):
         h264 = await self.receive_h264()
+        if h264 is None:
+            raise RuntimeError("receive_h264 returned no data (stream closed before a full frame was received)")
         with tempfile.NamedTemporaryFile() as h264file, tempfile.NamedTemporaryFile() as jpegfile:
             h264file.write(h264)
             os.system(f"/opt/x1plus/bin/h264tojpeg {h264file.name} {jpegfile.name}")

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/modules/camera_watchdog.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/modules/camera_watchdog.py
@@ -1,0 +1,235 @@
+"""
+Periodically probes the ipcam service and restarts it if unresponsive.
+
+The Bambu ipcam binary has a known resource leak: after enough
+connect/disconnect cycles it stops accepting new RTSP connections without
+crashing. Because the process stays alive sys_monitor never restarts it,
+so the camera appears dead until the printer is rebooted.
+
+A bare TCP probe is insufficient: when ipcam exhausts its MPP session pool
+it continues accepting TCP connections on port 322 while being unable to
+serve RTSP. This module probes at the RTSP layer by establishing a TLS
+connection and sending an OPTIONS request. A valid RTSP response confirms
+ipcam is healthy; a timeout or connection error triggers a stop; service_check
+will restart it automatically.
+
+After restart, if the RTSP server was previously enabled, the module
+restores it by publishing {"restore_camera_rtsp": true} on the
+device/x1plus DDS topic. A handler added to GpioKeys.js receives this
+and calls RecordManager.rtspServerOn = true inside bbl_screen's own
+process, which causes bbl_screen to send the liveview init command to
+ipcam via its internal DDS channel — the same path as a user toggle.
+
+Note: ipcam accepts RTSP commands on device/request/liveview, but the
+init command requires credentials that bbl_screen manages internally.
+Publishing via device/x1plus through GpioKeys.js is simpler — it reuses
+bbl_screen's existing code path and avoids sourcing credentials from
+printer config.
+
+Settings:
+  camera.watchdog.interval - int, probe interval in seconds (default: 300)
+
+[X1PLUS_MODULE_INFO]
+module:
+  name: camera_watchdog
+  default_enabled: true
+[END_X1PLUS_MODULE_INFO]
+"""
+
+import asyncio
+import json
+import logging
+import ssl
+import subprocess
+
+import x1plus.dds
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL      = 300
+PROBE_TIMEOUT         = 10
+IPCAM_HOST            = "127.0.0.1"
+IPCAM_PORT            = 322
+IPCAM_INIT            = "/etc/init.d/S99ipcam_service"
+PRINTER_JSON          = "/config/screen/printer.json"
+
+# service_check polls every 5 s, so ipcam could take up to 5 s to be
+# restarted after we stop it, plus ~3 s to start up; 8 s is comfortable.
+RESTART_SETTLE_TIME   = 8
+
+BOOT_POLL_INTERVAL    = 10
+
+RTSP_RESTORE_RETRIES  = 3
+RTSP_RESTORE_INTERVAL = 5
+
+# Publish on device/x1plus — the channel bbl_screen already subscribes
+# to for X1Plus messages.  A handler in GpioKeys.js receives
+# restore_camera_rtsp and calls RecordManager.rtspServerOn directly
+# inside bbl_screen, which then sends the liveview init to ipcam via
+# bbl_screen's own internal DDS channel.
+_x1plus_pub = x1plus.dds.publisher("device/x1plus")
+
+
+def _printer_json_rtsp_enabled() -> bool:
+    """
+    Read rtspServer from /config/screen/printer.json.
+    bbl_screen only clears rtspServer after a clean ipcam disconnect,
+    so this remains true when ipcam is stuck — the real failure case.
+    """
+    try:
+        with open(PRINTER_JSON, "r") as f:
+            enabled = bool(json.load(f).get("rtspServer", False))
+        logger.debug(f"printer.json rtspServer={enabled}")
+        return enabled
+    except FileNotFoundError:
+        return False
+    except Exception as e:
+        logger.warning(f"could not read printer.json: {e}")
+        return False
+
+
+class CameraWatchdog:
+    def __init__(self, daemon):
+        self.daemon = daemon
+
+    async def _probe_camera(self) -> bool:
+        """
+        Probe ipcam by completing a TLS handshake on port 322.
+
+        A TLS handshake is sufficient to determine whether ipcam is alive
+        and its network stack is functional, without sending any RTSP data.
+        Sending RTSP OPTIONS and immediately disconnecting was observed to
+        trigger a "Liveview failed to open" error in bbl_screen, likely
+        because ipcam emits a DDS status event when a client disconnects
+        unexpectedly that bbl_screen misinterprets as a stream failure.
+
+        A TLS-only probe is invisible to the RTSP layer and causes no
+        side effects. If ipcam is truly dead or hung, the TLS handshake
+        will either be refused (ECONNREFUSED) or time out.
+        """
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode    = ssl.CERT_NONE
+
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(IPCAM_HOST, IPCAM_PORT, ssl=ssl_ctx),
+                timeout=PROBE_TIMEOUT,
+            )
+            # TLS handshake succeeded — ipcam is alive.
+            # Close immediately without sending any RTSP data.
+            writer.close()
+            await writer.wait_closed()
+            return True
+
+        except (asyncio.TimeoutError, OSError, ssl.SSLError) as e:
+            logger.warning(f"camera probe failed: {e}")
+            return False
+
+    def _mqtt_rtsp_state(self):
+        """
+        Return rtsp_url from the latest MQTT push_status, or None if unavailable.
+        """
+        ipcam = self.daemon.mqtt.latest_print_status.get("ipcam", {})
+        return ipcam.get("rtsp_url")
+
+    async def _restore_rtsp(self):
+        """
+        Re-enable the RTSP server after restart by publishing
+        restore_camera_rtsp on device/x1plus.  The GpioKeys.js handler in
+        bbl_screen receives this and calls RecordManager.rtspServerOn = true,
+        which causes bbl_screen to send the liveview init to ipcam directly.
+        Confirms success via MQTT push_status with retries.
+        """
+        for attempt in range(1, RTSP_RESTORE_RETRIES + 1):
+            current = self._mqtt_rtsp_state()
+            logger.debug(f"RTSP restore attempt {attempt}: MQTT rtsp_url={current!r}")
+
+            if current is not None and current != "disable":
+                logger.info(f"RTSP server is enabled (rtsp_url={current!r}) — restore complete")
+                return
+
+            logger.info(
+                f"RTSP not enabled (rtsp_url={current!r}), "
+                f"requesting restore via bbl_screen "
+                f"(attempt {attempt}/{RTSP_RESTORE_RETRIES})"
+            )
+            _x1plus_pub(json.dumps({"restore_camera_rtsp": True}))
+            await asyncio.sleep(RTSP_RESTORE_INTERVAL)
+
+        current = self._mqtt_rtsp_state()
+        if current is not None and current != "disable":
+            logger.info(f"RTSP server restored successfully (rtsp_url={current!r})")
+        else:
+            logger.warning(
+                "RTSP server could not be restored automatically after "
+                f"{RTSP_RESTORE_RETRIES} attempts — toggle it manually in LAN access settings"
+            )
+
+    async def _stop_ipcam(self, rtsp_enabled: bool):
+        """Stop ipcam via its init script; service_check will restart it, then restore RTSP state."""
+        logger.warning(
+            f"stopping ipcam service "
+            f"(RTSP was {'enabled' if rtsp_enabled else 'disabled'})"
+        )
+
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    [IPCAM_INIT, "stop"],
+                    capture_output=True,
+                    text=True,
+                ),
+            )
+            if result.returncode == 0:
+                logger.info("ipcam service stopped; service_check will restart it")
+            else:
+                logger.error(
+                    f"ipcam stop returned {result.returncode}: "
+                    f"{result.stderr.strip()}"
+                )
+                return
+        except Exception as e:
+            logger.error(f"failed to stop ipcam service: {e}")
+            return
+
+        if rtsp_enabled:
+            logger.info(
+                f"waiting {RESTART_SETTLE_TIME}s for ipcam to settle "
+                "before restoring RTSP state"
+            )
+            await asyncio.sleep(RESTART_SETTLE_TIME)
+            await self._restore_rtsp()
+
+    async def task(self):
+        logger.info("camera watchdog started, waiting for ipcam to become ready")
+
+        while not await self._probe_camera():
+            logger.debug(f"ipcam not yet ready, retrying in {BOOT_POLL_INTERVAL}s")
+            await asyncio.sleep(BOOT_POLL_INTERVAL)
+
+        logger.info("ipcam ready, starting watchdog loop")
+
+        while True:
+            interval = self.daemon.settings.get(
+                "camera.watchdog.interval", DEFAULT_INTERVAL
+            )
+            await asyncio.sleep(interval)
+
+            if not await self._probe_camera():
+                rtsp_enabled = _printer_json_rtsp_enabled()
+                await self._stop_ipcam(rtsp_enabled)
+            else:
+                logger.debug("camera RTSP probe OK")
+
+
+_daemon = None
+
+def load(daemon):
+    global _daemon
+    _daemon = daemon
+    daemon.camera_watchdog = CameraWatchdog(daemon=daemon)
+
+def start():
+    asyncio.create_task(_daemon.camera_watchdog.task())

--- a/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
+++ b/images/cfw/opt/x1plus/lib/python/x1plus/services/x1plusd/mqtt.py
@@ -46,6 +46,10 @@ class MQTTClient():
                     # (AMS data is not always included in every push_status)
                     if 'ams' not in new_status and 'ams' in self.latest_print_status:
                         new_status['ams'] = self.latest_print_status['ams']
+                    # Preserve ipcam state across push_status updates that
+                    # don't include it, same as AMS.
+                    if 'ipcam' not in new_status and 'ipcam' in self.latest_print_status:
+                        new_status['ipcam'] = self.latest_print_status['ipcam']
                     self.latest_print_status = new_status
                 for handler in self.report_message_handlers.copy(): # avoid problems if this gets mutated out from under us mid handler
                     await handler(payload)


### PR DESCRIPTION
Implements a camera watchdog module for x1plusd that periodically probes the ipcam service and recovers it when unresponsive.

The Bambu ipcam binary has a known resource leak — after enough connect/disconnect cycles it stops accepting new RTSP connections without crashing. Because the process stays alive, sys_monitor never restarts it, leaving the camera dead until the printer is rebooted.

## What it does

- Probes ipcam on boot by polling every 10s until the first successful TLS handshake, then enters the watchdog loop
- Probes at the TLS layer on port 322 at a configurable interval (default 5 min)
- On failure, stops ipcam via its init script and lets service_check restart it, avoiding a race condition where calling restart directly could result in two ipcam instances starting simultaneously
- Reads rtspServer from /config/screen/printer.json to determine if RTSP was enabled before the failure, then restores it via the device/x1plus DDS bridge through GpioKeys.js

## Settings

-  — probe interval in seconds (default: 300)

Extracted from #554.