### PR TITLE
bbl_screen: show filament remaining percentage on FilamentPage

### DIFF
--- a/bbl_screen-patch/patches/printerui/qml/printer/FilamentPage.qml.patch
+++ b/bbl_screen-patch/patches/printerui/qml/printer/FilamentPage.qml.patch
@@ -17,7 +17,19 @@
      MarginPanel {
          id: howToPanel
          height: 538
-@@ -651,36 +652,49 @@
+@@ -633,8 +634,8 @@
+                     Text {
+                         width: parent.width - 10
+-                        y: 50
++                        y: 30
+                         anchors.horizontalCenter: parent.horizontalCenter
+                         font: Fonts.body_26
+                         minimumPixelSize: 10
+                         fontSizeMode: Text.HorizontalFit
+                         horizontalAlignment: Text.AlignHCenter
+@@ -650,37 +651,50 @@
+-                        text: modelData.exist ? (modelData.typeName + "").replace(" ", "\n")
++                        text: modelData.exist ? (modelData.typeName + "").replace(" ", "\n") + (modelData.remain >= 0 ? "\n" + modelData.remain + "%" : "")
                                                : qsTr("Empty")
                      }
  


### PR DESCRIPTION
Adds filament remaining percentage below the filament type label on the FilamentPage. The percentage is only shown when `modelData.remain` is non-negative (i.e. the printer has valid remaining data). The label is shifted up slightly to make room.

This was broken out as a focused PR from #554.